### PR TITLE
TryteString.random() use cls.LEN as its default length, when available

### DIFF
--- a/iota/types.py
+++ b/iota/types.py
@@ -49,7 +49,7 @@ class TryteString(JsonSerializable):
   IMPORTANT: A TryteString does not represent a numeric value!
   """
   @classmethod
-  def random(cls, length):
+  def random(cls, length=None):
     # type: (int) -> TryteString
     """
     Generates a random sequence of trytes.
@@ -59,6 +59,12 @@ class TryteString(JsonSerializable):
     """
     alphabet  = list(itervalues(AsciiTrytesCodec.alphabet))
     generator = SystemRandom()
+
+    try:
+      length = length or cls.LEN
+    except AttributeError:  # class has no LEN attribute
+      if length is None:
+        raise TypeError("random() missing 1 required positional argument: 'length'")
 
     # :py:meth:`SystemRandom.choices` wasn't added until Python 3.6;
     # for compatibility, we will continue to use ``choice`` in a loop.

--- a/iota/types.py
+++ b/iota/types.py
@@ -61,10 +61,14 @@ class TryteString(JsonSerializable):
     generator = SystemRandom()
 
     try:
-      length = length or cls.LEN
+      if length is None:
+        length = cls.LEN
+
+      if length <= 0:
+        raise TypeError("length parameter needs to be greater than zero")
     except AttributeError:  # class has no LEN attribute
       if length is None:
-        raise TypeError("random() missing 1 required positional argument: 'length'")
+        raise TypeError("{class_name} does not define a length property".format(class_name=cls.__name__))
 
     # :py:meth:`SystemRandom.choices` wasn't added until Python 3.6;
     # for compatibility, we will continue to use ``choice`` in a loop.


### PR DESCRIPTION
Fix #166 
