### PR TITLE
Update links in docs to iota.py

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -156,12 +156,12 @@ When you submit a Pull Request, here is what you can expect from the individual 
 - If any changes are needed, or if we cannot accept your submission, we will provide a respectful and constructive explanation.
 
 
-.. _come on over and help us out!: https://github.com/iotaledger/iota.lib.py/issues/145
+.. _come on over and help us out!: https://github.com/iotaledger/iota.py/issues/145
 .. _email you: https://help.github.com/articles/managing-notification-delivery-methods/
-.. _help wanted: https://github.com/iotaledger/iota.lib.py/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+.. _help wanted: https://github.com/iotaledger/iota.py/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
 .. _how to contribute to open source: https://opensource.guide/how-to-contribute/
 .. _notifications: https://github.com/notifications
 .. _pep-8: https://www.python.org/dev/peps/pep-0008/
-.. _pyota bug tracker: https://github.com/iotaledger/iota.lib.py/issues
+.. _pyota bug tracker: https://github.com/iotaledger/iota.py/issues
 .. _discord: https://discord.iota.org
 .. _tutorials: https://docs.iota.org

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/iotaledger/iota.lib.py.svg?branch=master
-   :target: https://travis-ci.org/iotaledger/iota.lib.py
+.. image:: https://travis-ci.org/iotaledger/iota.py.svg?branch=master
+   :target: https://travis-ci.org/iotaledger/iota.py
 
 .. image:: https://readthedocs.org/projects/pyota/badge/?version=latest
    :target: http://pyota.readthedocs.io/en/latest/?badge=latest
@@ -47,7 +47,7 @@ Installing from Source
 ======================
 
 #. `Create virtualenv`_ (recommended, but not required).
-#. ``git clone https://github.com/iotaledger/iota.lib.py.git``
+#. ``git clone https://github.com/iotaledger/iota.py.git``
 #. ``pip install -e .``
 
 Running Unit Tests
@@ -97,7 +97,7 @@ can also build the documentation locally:
 
 .. _Create virtualenv: https://realpython.com/blog/python/python-virtual-environments-a-primer/
 .. _Discord: https://discord.iota.org/
-.. _PyOTA Bug Tracker: https://github.com/iotaledger/iota.lib.py/issues
+.. _PyOTA Bug Tracker: https://github.com/iotaledger/iota.py/issues
 .. _ReadTheDocs: https://pyota.readthedocs.io/
 .. _official API: https://docs.iota.org/docs/node-software/0.1/iri/references/api-reference
 .. _tox: https://tox.readthedocs.io/

--- a/docs/multisig.rst
+++ b/docs/multisig.rst
@@ -209,5 +209,5 @@ Never share your private keys
 
 Under no circumstances - other than wanting to reduce the requirements for a multi-signature (see section **How M-of-N works**) - should you share your private keys. Sharing your private keys with others means that they can sign your part of the multi-signature successfully.
 
-.. _example: https://github.com/iotaledger/iota.lib.py/blob/develop/examples/multisig.py
+.. _example: https://github.com/iotaledger/iota.py/blob/develop/examples/multisig.py
 .. _wiki: https://github.com/iotaledger/wiki/blob/master/multisigs.md

--- a/iota/adapter/__init__.py
+++ b/iota/adapter/__init__.py
@@ -33,13 +33,13 @@ if PY2:
     # (note: ``imp`` is deprecated since Python 3.4 in favor of
     # ``importlib``).
     # https://docs.python.org/3/library/imp.html
-    # https://travis-ci.org/iotaledger/iota.lib.py/jobs/191974244
+    # https://travis-ci.org/iotaledger/iota.py/jobs/191974244
     __all__ = map(binary_type, __all__)
 
 API_VERSION = '1'
 """
 API protocol version.
-https://github.com/iotaledger/iota.lib.py/issues/84
+https://github.com/iotaledger/iota.py/issues/84
 """
 
 # Custom types for type hints and docstrings.
@@ -219,7 +219,7 @@ class HttpAdapter(BaseAdapter):
     DEFAULT_HEADERS = {
         'Content-type': 'application/json',
 
-        # https://github.com/iotaledger/iota.lib.py/issues/84
+        # https://github.com/iotaledger/iota.py/issues/84
         'X-IOTA-API-Version': API_VERSION,
     }
     """

--- a/iota/adapter/sandbox.py
+++ b/iota/adapter/sandbox.py
@@ -35,7 +35,7 @@ class SandboxAdapter(HttpAdapter):
     completed successfully.
 
     References:
-        - https://github.com/iotaledger/iota.lib.py/issues/19
+        - https://github.com/iotaledger/iota.py/issues/19
         - https://github.com/iotaledger/documentation/blob/sandbox/source/index.html.md
     """
     DEFAULT_POLL_INTERVAL = 15

--- a/iota/api.py
+++ b/iota/api.py
@@ -103,13 +103,13 @@ class StrictIota(object):
         - https://docs.iota.org/docs/node-software/0.1/iri/references/api-reference
         """
         # Fix an error when invoking :py:func:`help`.
-        # https://github.com/iotaledger/iota.lib.py/issues/41
+        # https://github.com/iotaledger/iota.py/issues/41
         if command == '__name__':
             # noinspection PyTypeChecker
             return None
 
         # Fix an error when invoking dunder methods.
-        # https://github.com/iotaledger/iota.lib.py/issues/206
+        # https://github.com/iotaledger/iota.py/issues/206
         if command.startswith("__"):
             # noinspection PyUnresolvedReferences
             return super(StrictIota, self).__getattr__(command)

--- a/iota/commands/__init__.py
+++ b/iota/commands/__init__.py
@@ -59,7 +59,7 @@ def discover_commands(package, recursively=True):
 
     # Prefix in name module move to function "walk_packages" for fix
     # conflict with names importing packages
-    # Bug https://github.com/iotaledger/iota.lib.py/issues/63
+    # Bug https://github.com/iotaledger/iota.py/issues/63
     sub_package = import_module(name)
 
     # Index any command classes that we find.

--- a/iota/commands/core/find_transactions.py
+++ b/iota/commands/core/find_transactions.py
@@ -84,7 +84,7 @@ class FindTransactionsRequestFilter(RequestFilter):
 
         # Remove null search terms.
         # Note: We will assume that empty lists are intentional.
-        # https://github.com/iotaledger/iota.lib.py/issues/96
+        # https://github.com/iotaledger/iota.py/issues/96
         search_terms = {
             term: query
             for term, query in iteritems(value)

--- a/iota/commands/extended/helpers.py
+++ b/iota/commands/extended/helpers.py
@@ -10,7 +10,7 @@ class Helpers(object):
     Adds additional helper functions that aren't part of the core or
     extended API.
 
-    See https://github.com/iotaledger/iota.lib.py/pull/124 for more
+    See https://github.com/iotaledger/iota.py/pull/124 for more
     context.
     """
 

--- a/iota/transaction/creation.py
+++ b/iota/transaction/creation.py
@@ -98,7 +98,7 @@ class ProposedTransaction(Transaction):
 
         References:
 
-        - https://github.com/iotaledger/iota.lib.py/issues/84
+        - https://github.com/iotaledger/iota.py/issues/84
         """
         self._legacy_tag = (
             Tag.from_trits(add_trits(self.legacy_tag.as_trits(), [1]))
@@ -108,7 +108,7 @@ class ProposedTransaction(Transaction):
 Transfer = ProposedTransaction
 """
 Follow naming convention of other libs.
-https://github.com/iotaledger/iota.lib.py/issues/72
+https://github.com/iotaledger/iota.py/issues/72
 """
 
 
@@ -366,7 +366,7 @@ class ProposedBundle(Bundle, Sequence[ProposedTransaction]):
             bundle_hash = BundleHash.from_trits(bundle_hash_trits)
 
             # Check that we generated a secure bundle hash.
-            # https://github.com/iotaledger/iota.lib.py/issues/84
+            # https://github.com/iotaledger/iota.py/issues/84
             if any(13 in part for part in normalize(bundle_hash)):
                 # Increment the legacy tag and try again.
                 tail_transaction = (

--- a/iota/types.py
+++ b/iota/types.py
@@ -83,7 +83,7 @@ class TryteString(JsonSerializable):
         :param codec:
             Reserved for future use.
 
-            See https://github.com/iotaledger/iota.lib.py/issues/62 for
+            See https://github.com/iotaledger/iota.py/issues/62 for
             more information.
 
         :param args:
@@ -121,7 +121,7 @@ class TryteString(JsonSerializable):
         """
         Deprecated; use :py:meth:`from_unicode` instead.
 
-        https://github.com/iotaledger/iota.lib.py/issues/90
+        https://github.com/iotaledger/iota.py/issues/90
         """
         warn(
             category=DeprecationWarning,
@@ -499,7 +499,7 @@ class TryteString(JsonSerializable):
         :param codec:
             Reserved for future use.
 
-            See https://github.com/iotaledger/iota.lib.py/issues/62 for
+            See https://github.com/iotaledger/iota.py/issues/62 for
             more information.
 
         :raise:
@@ -511,7 +511,7 @@ class TryteString(JsonSerializable):
         # :py:class:`AsciiTrytesCodec`.
         #
         # Once we add more codecs, we may need to revisit this.
-        # See https://github.com/iotaledger/iota.lib.py/issues/62 for
+        # See https://github.com/iotaledger/iota.py/issues/62 for
         # more information.
         return decode(self._trytes, codec, errors)
 
@@ -519,7 +519,7 @@ class TryteString(JsonSerializable):
         """
         Deprecated; use :py:meth:`encode` instead.
 
-        https://github.com/iotaledger/iota.lib.py/issues/90
+        https://github.com/iotaledger/iota.py/issues/90
         """
         warn(
             category=DeprecationWarning,
@@ -570,7 +570,7 @@ class TryteString(JsonSerializable):
         """
         Deprecated; use :py:meth:`decode` instead.
 
-        https://github.com/iotaledger/iota.lib.py/issues/90
+        https://github.com/iotaledger/iota.py/issues/90
         """
         warn(
             category=DeprecationWarning,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ tests_require = [
 setuptools.setup(
     name='PyOTA',
     description='IOTA API library for Python',
-    url='https://github.com/iotaledger/iota.lib.py',
+    url='https://github.com/iotaledger/iota.py',
     version='2.0.9',
 
     long_description=long_description,

--- a/test/adapter_test.py
+++ b/test/adapter_test.py
@@ -153,7 +153,7 @@ class HttpAdapterTestCase(TestCase):
 
     self.assertEqual(result, expected_result)
 
-    # https://github.com/iotaledger/iota.lib.py/issues/84
+    # https://github.com/iotaledger/iota.py/issues/84
     mocked_sender.assert_called_once_with(
       headers = {
         'Content-type':       'application/json',

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -145,7 +145,7 @@ class IotaApiTestCase(TestCase):
         class definition raises an exception.
 
         References:
-            - https://github.com/iotaledger/iota.lib.py/issues/206
+            - https://github.com/iotaledger/iota.py/issues/206
         """
         # This statement will raise an exception if the regression is
         # present; no assertions necessary.

--- a/test/commands/core/find_transactions_test.py
+++ b/test/commands/core/find_transactions_test.py
@@ -140,7 +140,7 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
         ],
 
         # Null criteria are not included in the request.
-        # https://github.com/iotaledger/iota.lib.py/issues/96
+        # https://github.com/iotaledger/iota.py/issues/96
         # 'addresses':  [],
         # 'approvees':  [],
         # 'tags':       [],
@@ -171,7 +171,7 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
         ],
 
         # Null criteria are not included in the request.
-        # https://github.com/iotaledger/iota.lib.py/issues/96
+        # https://github.com/iotaledger/iota.py/issues/96
         # 'approvees':  [],
         # 'bundles':    [],
         # 'tags':       [],
@@ -202,7 +202,7 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
         ],
 
         # Null criteria are not included in the request.
-        # https://github.com/iotaledger/iota.lib.py/issues/96
+        # https://github.com/iotaledger/iota.py/issues/96
         # 'addresses':  [],
         # 'approvees':  [],
         # 'bundles':    [],
@@ -233,7 +233,7 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
         ],
 
         # Null criteria are not included in the request.
-        # https://github.com/iotaledger/iota.lib.py/issues/96
+        # https://github.com/iotaledger/iota.py/issues/96
         # 'addresses':  [],
         # 'bundles':    [],
         # 'tags':       [],

--- a/test/commands/core/get_tips_test.py
+++ b/test/commands/core/get_tips_test.py
@@ -130,7 +130,7 @@ class GetTipsCommandTestCase(TestCase):
     """
     The result is coerced to the proper type.
 
-    https://github.com/iotaledger/iota.lib.py/issues/130
+    https://github.com/iotaledger/iota.py/issues/130
     """
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('getTips', {

--- a/test/commands/extended/replay_bundle_test.py
+++ b/test/commands/extended/replay_bundle_test.py
@@ -602,7 +602,7 @@ class ReplayBundleCommandTestCase(TestCase):
       to replay the bundle.
 
       References:
-        - https://github.com/iotaledger/iota.lib.py/issues/74
+        - https://github.com/iotaledger/iota.py/issues/74
       """
       self.assertEqual(request['trytes'], send_trytes_response['trytes'])
       return send_trytes_response

--- a/test/crypto/types_test.py
+++ b/test/crypto/types_test.py
@@ -32,7 +32,7 @@ class SeedTestCase(TestCase):
     self.assertIsInstance(seed, Seed)
 
     # Regression test: Random seed must be exactly 81 trytes long.
-    # https://github.com/iotaledger/iota.lib.py/issues/44
+    # https://github.com/iotaledger/iota.py/issues/44
     self.assertEqual(len(seed), Hash.LEN)
 
   def test_random_seed_too_long(self):

--- a/test/filters_test.py
+++ b/test/filters_test.py
@@ -80,7 +80,7 @@ class NodeUriTestCase(BaseFilterTestCase):
     """
     The incoming value is a valid TCP URI.
 
-    https://github.com/iotaledger/iota.lib.py/issues/111
+    https://github.com/iotaledger/iota.py/issues/111
     """
     self.assertFilterPasses('tcp://localhost:14265/node')
 

--- a/test/transaction/creation_test.py
+++ b/test/transaction/creation_test.py
@@ -495,7 +495,7 @@ They both licked their dry lips.
     When finalizing, the bundle detects an insecure bundle hash.
 
     References:
-      - https://github.com/iotaledger/iota.lib.py/issues/84
+      - https://github.com/iotaledger/iota.py/issues/84
     """
     # noinspection SpellCheckingInspection
     bundle =\

--- a/test/trits_test.py
+++ b/test/trits_test.py
@@ -19,7 +19,7 @@ class TritsFromIntTestCase(TestCase):
     """
     Zero is represented as ``[0]`` by default.
 
-    https://github.com/iotaledger/iota.lib.py/issues/49
+    https://github.com/iotaledger/iota.py/issues/49
     """
     self.assertEqual(trits_from_int(0), [0])
 

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -777,7 +777,7 @@ class TryteStringTestCase(TestCase):
     :py:meth:`TryteString.from_string` is deprecated in favor of
     :py:meth:`TryteString.from_unicode`.
 
-    https://github.com/iotaledger/iota.lib.py/issues/90
+    https://github.com/iotaledger/iota.py/issues/90
     """
     with catch_warnings(record=True) as caught_warnings:
       simple_filter('always', category=DeprecationWarning)


### PR DESCRIPTION
Renaming repo iotaledger/iota.lib.py to iotaledger/iota.py, updating links in documentation and comments.