### PR TITLE
Implement getTransactionObjects command

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -216,6 +216,25 @@ This method returns a ``dict`` with the following items:
 -  ``addresses: List[Address]``: The generated address(es). Note that
    this value is always a list, even if only one address was generated.
 
+``get_transaction_objects``
+---------------------------
+Returns a list of transaction objects given a list of transaction hashes.
+This is effectively calling ``get_trytes`` and converting the trytes to
+transaction objects.
+Similar to ``find_transaction_objects``, but input is list of hashes.
+
+Parameters
+~~~~~~~~~~
+
+- ``hashes``: List of transaction hashes that should be fetched.
+
+Return
+~~~~~~
+
+Returns a ``dict`` with the following items:
+
+- ``transactions: List[Transaction]``: List of transaction objects.
+
 ``get_transfers``
 -----------------
 

--- a/iota/api.py
+++ b/iota/api.py
@@ -877,6 +877,36 @@ class Iota(StrictIota):
             seed=self.seed,
         )
 
+    def get_transaction_objects(
+            self,
+            hashes,  # type: [Iterable[TransactionHash]]
+    ):
+        # type: (...) -> dict
+        """
+        Fetches transaction objects from the Tangle given their
+        transaction IDs (hashes).
+
+        Effectively, this is ``get_trytes`` +
+        converting the trytes into transaction objects.
+
+        Similar to :py:meth:`find_transaction_objects`, but accepts
+        list of trnsaction hashes as input.
+
+        :param hashes:
+          List of transaction IDs (transaction hashes).
+
+        :return:
+            Dict with the following structure::
+
+                {
+                    'transactions': List[Transaction],
+                        List of Transaction objects that match the input.
+                }
+        """
+        return extended.GetTransactionObjectsCommand(self.adapter)(
+            hashes=hashes,
+        )
+
     def get_transfers(self, start=0, stop=None, inclusion_states=False):
         # type: (int, Optional[int], bool) -> dict
         """

--- a/iota/commands/extended/__init__.py
+++ b/iota/commands/extended/__init__.py
@@ -18,6 +18,7 @@ from .get_bundles import *
 from .get_inputs import *
 from .get_latest_inclusion import *
 from .get_new_addresses import *
+from .get_transaction_objects import *
 from .get_transfers import *
 from .is_reattachable import *
 from .prepare_transfer import *

--- a/iota/commands/extended/get_transaction_objects.py
+++ b/iota/commands/extended/get_transaction_objects.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from typing import Iterable, List, Optional
+
+import filters as f
+
+from iota import Transaction, TransactionHash
+from iota.commands.core import GetTrytesCommand
+from iota.commands import FilterCommand, RequestFilter
+from iota.filters import Trytes
+
+__all__ = [
+    'GetTransactionObjectsCommand',
+]
+
+
+class GetTransactionObjectsCommand(FilterCommand):
+    """
+    Executes `GetTransactionObjectsCommand` command.
+
+    See :py:meth:`iota.api.StrictIota.get_transaction_objects`.
+    """
+    command = 'getTransactionObjects'
+
+    def get_request_filter(self):
+        return GetTransactionObjectsRequestFilter()
+
+    def get_response_filter(self):
+        pass
+
+    def _execute(self, request):
+        hashes = request\
+            .get('hashes') # type: Optional[Iterable[TransactionHash]]
+
+        transactions = []
+        if hashes:
+            gt_response = GetTrytesCommand(adapter=self.adapter)(hashes=hashes)
+
+            transactions = list(map(
+                Transaction.from_tryte_string,
+                gt_response.get('trytes') or [],
+            ))  # type: List[Transaction]
+
+        return {
+            'transactions': transactions,
+        }
+
+class GetTransactionObjectsRequestFilter(RequestFilter):
+    def __init__(self):
+        super(GetTransactionObjectsRequestFilter, self).__init__({
+            'hashes':
+                f.Required | f.Array | f.FilterRepeater(
+                    f.Required |
+                    Trytes(TransactionHash) |
+                    f.Unicode(encoding='ascii', normalize=False),
+                ),
+        })

--- a/iota/commands/extended/get_transaction_objects.py
+++ b/iota/commands/extended/get_transaction_objects.py
@@ -9,7 +9,7 @@ import filters as f
 from iota import Transaction, TransactionHash
 from iota.commands.core import GetTrytesCommand
 from iota.commands import FilterCommand, RequestFilter
-from iota.filters import Trytes
+from iota.filters import StringifiedTrytesArray
 
 __all__ = [
     'GetTransactionObjectsCommand',
@@ -20,7 +20,7 @@ class GetTransactionObjectsCommand(FilterCommand):
     """
     Executes `GetTransactionObjectsCommand` command.
 
-    See :py:meth:`iota.api.StrictIota.get_transaction_objects`.
+    See :py:meth:`iota.api.Iota.get_transaction_objects`.
     """
     command = 'getTransactionObjects'
 
@@ -32,7 +32,7 @@ class GetTransactionObjectsCommand(FilterCommand):
 
     def _execute(self, request):
         hashes = request\
-            .get('hashes') # type: Optional[Iterable[TransactionHash]]
+            .get('hashes') # type: Iterable[TransactionHash]
 
         transactions = []
         if hashes:
@@ -51,9 +51,5 @@ class GetTransactionObjectsRequestFilter(RequestFilter):
     def __init__(self):
         super(GetTransactionObjectsRequestFilter, self).__init__({
             'hashes':
-                f.Required | f.Array | f.FilterRepeater(
-                    f.Required |
-                    Trytes(TransactionHash) |
-                    f.Unicode(encoding='ascii', normalize=False),
-                ),
+                StringifiedTrytesArray(TransactionHash) | f.Required
         })

--- a/test/commands/extended/get_transaction_objects_test.py
+++ b/test/commands/extended/get_transaction_objects_test.py
@@ -1,0 +1,111 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from unittest import TestCase
+
+import mock
+
+from iota import Iota, MockAdapter, Transaction
+from iota.commands.extended import GetTransactionObjectsCommand
+
+
+class GetTransactionObjectsCommandTestCase(TestCase):
+    # noinspection SpellCheckingInspection
+    def setUp(self):
+        super(GetTransactionObjectsCommandTestCase, self).setUp()
+
+        self.adapter = MockAdapter()
+        self.command = GetTransactionObjectsCommand(self.adapter)
+
+        # Define values that we can reuse across tests.
+        self.transaction_hash = \
+            b'BROTOVRCAEMFLRWGPVWDPDTBRAMLHVCHQDEHXLCWH' \
+            b'KKXLVDFCPIJEUZTPPFMPQQ9KOHAEUAMMVJN99999'
+        self.trytes = \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999999999999999999999999999999999999999999999999' \
+            b'99999999999999999AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' \
+            b'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA99999999999999999999999999' \
+            b'9QC9999999999999999999999999PQYJHAD99999999999999999999WHIUDFV' \
+            b'IFXNBJVEHYPLDADIDINGAWMHYIJNPYUDWXCAWL9GSKTUIZLJGGFIXEIYTJEDQZ' \
+            b'TIYRXHC9PBWBDSOTEJTQTYYSZLVTFLDQMZSGLHKLYVJOLMXIJJRTGS9RYBXLAT' \
+            b'ZJXBVBCPUGWRUKZJYLBGPKRKWIA9999FPYHMFFWMMKOHTSAPMMATZQLWXJSPMT' \
+            b'JSRQIPMDCQXFFMXMHCYDKVJCFSRECAVALCOFIYCJLNRZZZ9999999999999999' \
+            b'999999999999999KITCXNZOF999999999MMMMMMMMMEA9999F9999999999999' \
+            b'9999999'
+
+    def test_wireup(self):
+        """
+        Verify that the command is wired up correctly.
+        """
+        self.assertIsInstance(
+            Iota(self.adapter).getTransactionObjects,
+            GetTransactionObjectsCommand,
+        )
+
+    def test_transaction_found(self):
+        """
+        A transaction is found with the inputs. A transaction object is
+        returned
+        """
+        with mock.patch(
+            'iota.commands.core.get_trytes.GetTrytesCommand._execute',
+            mock.Mock(return_value={'trytes': [self.trytes, ]}),
+        ):
+            response = self.command(hashes=[self.transaction_hash])
+
+        self.assertEqual(len(response['transactions']), 1)
+        transaction = response['transactions'][0]
+        self.assertIsInstance(transaction, Transaction)
+        self.assertEqual(transaction.hash, self.transaction_hash)
+
+    def test_no_transactions_fround(self):
+        """
+        No transaction is found with the inputs. An empty list is returned
+        """
+        with mock.patch(
+            'iota.commands.core.get_trytes.GetTrytesCommand._execute',
+            mock.Mock(return_value={'trytes': []}),
+        ):
+            response = self.command(hashes=[self.transaction_hash])
+
+        self.assertDictEqual(
+            response,
+            {
+                'transactions': [],
+            },
+        )


### PR DESCRIPTION
New command to harmonize PyOTA with JS lib.
Similar to findTransactionObjects, but input
is a list of transaction hashes.

resolves #241 