### PR TITLE
Refactored repeated filter logic into macro.

### DIFF
--- a/iota/commands/core/broadcast_transactions.py
+++ b/iota/commands/core/broadcast_transactions.py
@@ -6,7 +6,7 @@ import filters as f
 
 from iota import TransactionTrytes
 from iota.commands import FilterCommand, RequestFilter
-from iota.filters import Trytes
+from iota.filters import StringifiedTrytesArray
 
 __all__ = [
     'BroadcastTransactionsCommand',
@@ -31,12 +31,5 @@ class BroadcastTransactionsCommand(FilterCommand):
 class BroadcastTransactionsRequestFilter(RequestFilter):
     def __init__(self):
         super(BroadcastTransactionsRequestFilter, self).__init__({
-            'trytes':
-                f.Required |
-                f.Array |
-                f.FilterRepeater(
-                    f.Required |
-                    Trytes(TransactionTrytes) |
-                    f.Unicode(encoding='ascii', normalize=False),
-                ),
+            'trytes': StringifiedTrytesArray(TransactionTrytes) | f.Required,
         })

--- a/iota/commands/core/find_transactions.py
+++ b/iota/commands/core/find_transactions.py
@@ -7,7 +7,7 @@ from six import iteritems
 
 from iota import BundleHash, Tag, TransactionHash
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
-from iota.filters import AddressNoChecksum, Trytes
+from iota.filters import AddressNoChecksum, StringifiedTrytesArray, Trytes
 
 __all__ = [
     'FindTransactionsCommand',
@@ -46,26 +46,9 @@ class FindTransactionsRequestFilter(RequestFilter):
                         f.Unicode(encoding='ascii', normalize=False),
                     ),
 
-                'approvees':
-                    f.Array | f.FilterRepeater(
-                        f.Required |
-                        Trytes(TransactionHash) |
-                        f.Unicode(encoding='ascii', normalize=False),
-                    ),
-
-                'bundles':
-                    f.Array | f.FilterRepeater(
-                        f.Required |
-                        Trytes(BundleHash) |
-                        f.Unicode(encoding='ascii', normalize=False),
-                    ),
-
-                'tags':
-                    f.Array | f.FilterRepeater(
-                        f.Required |
-                        Trytes(Tag) |
-                        f.Unicode(encoding='ascii', normalize=False),
-                    ),
+                'approvees': StringifiedTrytesArray(TransactionHash),
+                'bundles': StringifiedTrytesArray(BundleHash),
+                'tags': StringifiedTrytesArray(Tag),
             },
 
             # Technically, all of the parameters for this command are

--- a/iota/commands/core/get_balances.py
+++ b/iota/commands/core/get_balances.py
@@ -7,7 +7,7 @@ from six import iteritems
 
 from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
-from iota.filters import AddressNoChecksum, Trytes
+from iota.filters import AddressNoChecksum, StringifiedTrytesArray, Trytes
 
 __all__ = [
     'GetBalancesCommand',
@@ -46,12 +46,7 @@ class GetBalancesRequestFilter(RequestFilter):
                     f.Max(100) |
                     f.Optional(default=100),
 
-                'tips':
-                    f.Array | f.FilterRepeater(
-                        f.Required |
-                        Trytes(TransactionHash) |
-                        f.Unicode(encoding='ascii', normalize=False),
-                    )
+                'tips': StringifiedTrytesArray(TransactionHash),
             },
 
             allow_missing_keys={

--- a/iota/commands/core/get_inclusion_states.py
+++ b/iota/commands/core/get_inclusion_states.py
@@ -6,7 +6,7 @@ import filters as f
 
 from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter
-from iota.filters import Trytes
+from iota.filters import StringifiedTrytesArray
 
 __all__ = [
     'GetInclusionStatesCommand',
@@ -34,19 +34,11 @@ class GetInclusionStatesRequestFilter(RequestFilter):
             {
                 # Required parameters.
                 'transactions':
-                    f.Required | f.Array | f.FilterRepeater(
-                        f.Required |
-                        Trytes(TransactionHash) |
-                        f.Unicode(encoding='ascii', normalize=False),
-                    ),
+                    StringifiedTrytesArray(TransactionHash) | f.Required,
 
                 # Optional parameters.
                 'tips':
-                    f.Array | f.FilterRepeater(
-                        f.Required |
-                        Trytes(TransactionHash) |
-                        f.Unicode(encoding='ascii', normalize=False),
-                    ) |
+                    StringifiedTrytesArray(TransactionHash) |
                     f.Optional(default=[]),
             },
 

--- a/iota/commands/core/get_trytes.py
+++ b/iota/commands/core/get_trytes.py
@@ -6,7 +6,7 @@ import filters as f
 
 from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
-from iota.filters import Trytes
+from iota.filters import StringifiedTrytesArray, Trytes
 
 __all__ = [
     'GetTrytesCommand',
@@ -32,11 +32,7 @@ class GetTrytesRequestFilter(RequestFilter):
     def __init__(self):
         super(GetTrytesRequestFilter, self).__init__({
             'hashes':
-                f.Required | f.Array | f.FilterRepeater(
-                    f.Required |
-                    Trytes(TransactionHash) |
-                    f.Unicode(encoding='ascii', normalize=False),
-                ),
+                StringifiedTrytesArray(TransactionHash) | f.Required,
         })
 
 

--- a/iota/commands/core/store_transactions.py
+++ b/iota/commands/core/store_transactions.py
@@ -6,7 +6,7 @@ import filters as f
 
 from iota import TransactionTrytes
 from iota.commands import FilterCommand, RequestFilter
-from iota.filters import Trytes
+from iota.filters import StringifiedTrytesArray
 
 __all__ = [
     'StoreTransactionsCommand',
@@ -32,9 +32,5 @@ class StoreTransactionsRequestFilter(RequestFilter):
     def __init__(self):
         super(StoreTransactionsRequestFilter, self).__init__({
             'trytes':
-                f.Required | f.Array | f.FilterRepeater(
-                    f.Required |
-                    Trytes(TransactionTrytes) |
-                    f.Unicode(encoding='ascii', normalize=False),
-                ),
+                StringifiedTrytesArray(TransactionTrytes) | f.Required,
         })

--- a/iota/commands/extended/is_reattachable.py
+++ b/iota/commands/extended/is_reattachable.py
@@ -10,7 +10,7 @@ from iota import Address
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
 from iota.commands.extended import FindTransactionObjectsCommand, \
     GetLatestInclusionCommand
-from iota.filters import Trytes
+from iota.filters import Trytes, StringifiedTrytesArray
 
 __all__ = [
     'IsReattachableCommand',
@@ -69,12 +69,7 @@ class IsReattachableRequestFilter(RequestFilter):
     def __init__(self):
         super(IsReattachableRequestFilter, self).__init__(
             {
-                'addresses':
-                    f.Required | f.Array | f.FilterRepeater(
-                        f.Required |
-                        Trytes(Address) |
-                        f.Unicode(encoding='ascii', normalize=False),
-                    ),
+                'addresses': StringifiedTrytesArray(Address) | f.Required,
             },
         )
 

--- a/iota/filters.py
+++ b/iota/filters.py
@@ -11,6 +11,15 @@ from six import binary_type, moves as compat, text_type
 from iota import Address, TryteString, TrytesCompatible
 from iota.crypto.addresses import AddressGenerator
 
+__all__ = [
+    'AddressNoChecksum',
+    'GeneratedAddress',
+    'NodeUri',
+    'SecurityLevel',
+    'StringifiedTrytesArray',
+    'Trytes',
+]
+
 
 class GeneratedAddress(f.BaseFilter):
     """
@@ -170,6 +179,30 @@ class Trytes(f.BaseFilter):
                     'result_type': self.result_type.__name__,
                 },
             )
+
+
+@filter_macro
+def StringifiedTrytesArray(trytes_type=TryteString):
+    """
+    Validates that the incoming value is an array containing tryte
+    strings corresponding to the specified type (e.g.,
+    ``TransactionHash``).
+
+    .. important::
+        This filter will return string values, suitable for inclusion in
+        an API request.  If you are expecting objects (e.g.,
+        :py:class:`Address`), then this is not the filter to use!
+
+    .. note::
+        This filter will allow empty arrays and `None`.  If this is not
+        desirable, chain this filter with ``f.NotEmpty`` or
+        ``f.Required``, respectively.
+    """
+    return f.Array | f.FilterRepeater(
+        f.Required |
+        Trytes(trytes_type) |
+        f.Unicode(encoding='ascii', normalize=False),
+    )
 
 
 class AddressNoChecksum(Trytes):

--- a/iota/filters.py
+++ b/iota/filters.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from typing import Text
+from typing import Text, Type
 
 import filters as f
 from filters.macros import filter_macro
@@ -181,8 +181,10 @@ class Trytes(f.BaseFilter):
             )
 
 
+# noinspection PyPep8Naming
 @filter_macro
 def StringifiedTrytesArray(trytes_type=TryteString):
+    # type: (Type[TryteString]) -> f.FilterChain
     """
     Validates that the incoming value is an array containing tryte
     strings corresponding to the specified type (e.g.,


### PR DESCRIPTION
Extracts copy-pasted filter logic into a new filter macro.  In particular, this reduces unit testing burden for new command request filters — we have plenty of coverage for the new `StringifiedTrytesArray` filter macro, so it shouldn't be necessary to write additional tests if a new command wants to use it.

See https://github.com/iotaledger/iota.py/pull/242#discussion_r332691663 for context.