### PR TITLE
Support for Local PoW

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,13 +44,12 @@ To install this extension, use the following command::
 
 Optional Local Pow
 ==================
-To perform Proof-of-Work locally without relying on any node,
+To perform proof-of-work locally without relying on a node,
 you can install an extension module called `PyOTA-PoW`_ .
 
 Specifiy the ``local_pow=True`` argument when creating an
 api instance, that will redirect all ``attach_to_tangle``
 API calls to an interface function in the ``pow`` package.
-Returns the same as a node would for the API call.
 
 To install this extension, use the following command::
 
@@ -118,5 +117,5 @@ can also build the documentation locally:
 .. _ReadTheDocs: https://pyota.readthedocs.io/
 .. _official API: https://docs.iota.org/docs/node-software/0.1/iri/references/api-reference
 .. _tox: https://tox.readthedocs.io/
-.. _Ccurl.interface.py: https://github.com/lzpap/ccurl.interface.py
+.. _Ccurl.interface.py: https://github.com/iotaledger/ccurl.interface.py
 .. _PyOTA-PoW: https://pypi.org/project/PyOTA-PoW/

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,23 @@ To install this extension, use the following command::
 
    pip install pyota[ccurl]
 
+Optional Local Pow
+==================
+To perform Proof-of-Work locally without relying on any node,
+you can install an extension module called `PyOTA-PoW`_ .
+
+Specifiy the ``local_pow=True`` argument when creating an
+api instance, that will redirect all ``attach_to_tangle``
+API calls to an interface function in the ``pow`` package.
+Returns the same as a node would for the API call.
+
+To install this extension, use the following command::
+
+   pip install pyota[pow]
+
+Alternativley you can take a look on the repository
+`Ccurl.interface.py`_  to install Pyota-PoW.
+Follow the steps depicted in the repo's README file.
 
 Installing from Source
 ======================
@@ -101,3 +118,5 @@ can also build the documentation locally:
 .. _ReadTheDocs: https://pyota.readthedocs.io/
 .. _official API: https://docs.iota.org/docs/node-software/0.1/iri/references/api-reference
 .. _tox: https://tox.readthedocs.io/
+.. _Ccurl.interface.py: https://github.com/lzpap/ccurl.interface.py
+.. _PyOTA-PoW: https://pypi.org/project/PyOTA-PoW/

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -213,6 +213,22 @@ depending on the command name.
 For example, you could use this wrapper to direct all PoW requests to a
 local node, while sending the other requests to a light wallet node.
 
+.. note::
+
+    A common use case for ``RoutingWrapper`` is to perform proof-of-work on
+    a specific (local) node, but let all other requests go to another node.
+    Take care when you use ``RoutingWrapper`` adapter and ``local_pow``
+    parameter together in an API instance, because the behavior might not
+    be obvious.
+
+    ``local_pow`` tells the API to perform proof-of-work (``attach_to_tangle``)
+    without relying on an actual node. It does this by calling an extension
+    package `PyOTA-PoW <https://pypi.org/project/PyOTA-PoW/>`_ that does the
+    job. In PyOTA, this means the request doesn't reach the adapter, it
+    is redirected before.
+    As a consequence,  ``local_pow`` has precedence over the route that is
+    defined in ``RoutingWrapper``.
+
 ``RoutingWrapper`` must be initialized with a default URI/adapter. This
 is the adapter that will be used for any command that doesn't have a
 route associated with it.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -6,7 +6,7 @@ Install PyOTA using `pip`:
 
 .. code-block:: bash
 
-   pip install pyota[ccurl]
+   pip install pyota[ccurl,pow]
 
 .. note::
 
@@ -14,6 +14,21 @@ Install PyOTA using `pip`:
 
    This extension boosts the performance of certain crypto operations
    significantly (speedups of 60x are common).
+
+.. note::
+
+   The ``[pow]`` extra installs the optional `PyOTA-PoW extension`_.
+
+   This extension makes it possible to perform proof-of-work
+   (api call ``attach_to_tangle``) locally, without relying on an iota node.
+   Use the ``local_pow`` parameter at api instantiation:
+
+   .. code::
+
+      api = Iota('https://nodes.thetangle.org:443', local_pow=True)
+
+   Or the ``set_local_pow`` method of the api class to dynamically enable/disable
+   the local proof-of-work feature.
 
 Getting Started
 ===============
@@ -78,6 +93,7 @@ your API requests so that they contain the necessary authentication metadata.
 .. _forum: https://forum.iota.org/
 .. _official api: https://docs.iota.org/docs/node-software/0.1/iri/references/api-reference
 .. _pyota-ccurl extension: https://pypi.python.org/pypi/PyOTA-CCurl
+.. _pyota-pow extension: https://pypi.org/project/PyOTA-PoW/
 .. _run your own node.: http://iotasupport.com/headlessnode.shtml
 .. _slack: http://slack.iota.org/
 .. _use a light wallet node.: http://iotasupport.com/lightwallet.shtml

--- a/examples/local_pow.py
+++ b/examples/local_pow.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, \
 
 import iota
 from pprint import pprint
-from datetime import datetime
 
 # Generate a random seed.
 myseed = iota.crypto.types.Seed.random()

--- a/examples/local_pow.py
+++ b/examples/local_pow.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+import iota
+from pprint import pprint
+from datetime import datetime
+
+# Generate a random seed.
+myseed = iota.crypto.types.Seed.random()
+# Get an address generator.
+addres_generator = iota.crypto.addresses.AddressGenerator(myseed)
+
+# Instantiate API. Note the `local_pow=True` argument.
+# This will cause PyOTA to do proof-of-work locally,
+# by using the pyota-pow extension package. (if installed)
+# Find it at: https://pypi.org/project/PyOTA-PoW/
+api = iota.Iota("https://nodes.thetangle.org:443",myseed,local_pow=True)
+
+# Generate two addresses
+addys = addres_generator.get_addresses(1, count=2)
+pprint('Generated addresses are:')
+pprint(addys)
+
+# Preparing transactions
+pt = iota.ProposedTransaction(address = iota.Address(addys[0]),
+                              message = iota.TryteString.from_unicode('Tx1: The PoW for this transaction was done by Pyota-Pow.'),
+                              tag     = iota.Tag(b'LOCALATTACHINTERFACE99999'), # Up to 27 trytes
+                              value   = 0)
+
+pt2 = iota.ProposedTransaction(address = iota.Address(addys[1]),
+                               message = iota.TryteString.from_unicode('Tx2: The PoW for this transaction was done by Pyota-Pow.'),
+                               tag     = iota.Tag(b'LOCALATTACHINTERFACE99999'), # Up to 27 trytes
+                               value   = 0)
+
+# `send_transfer` will take care of the rest
+response = api.send_transfer([pt,pt2])
+
+pprint('Broadcasted bundle:')
+pprint(response['bundle'].as_json_compatible())

--- a/iota/adapter/__init__.py
+++ b/iota/adapter/__init__.py
@@ -157,6 +157,7 @@ class BaseAdapter(object):
         super(BaseAdapter, self).__init__()
 
         self._logger = None  # type: Logger
+        self.local_pow = False # type: boolean
 
     @abstract_method
     def get_uri(self):
@@ -209,6 +210,15 @@ class BaseAdapter(object):
         if self._logger:
             self._logger.log(level, message, extra={'context': context or {}})
 
+    def set_local_pow(self, local_pow):
+        # type: (bool) -> None
+        """
+        Sets the local_pow attribute of the adapter. If it is true,
+        attach_to_tangle command calls external interface to perform
+        pow, instead of sending the request to a node.
+        By default, it is set to false.
+        """
+        self.local_pow = local_pow
 
 class HttpAdapter(BaseAdapter):
     """

--- a/iota/api.py
+++ b/iota/api.py
@@ -67,8 +67,8 @@ class StrictIota(object):
     """
     commands = discover_commands('iota.commands.core')
 
-    def __init__(self, adapter, testnet=False):
-        # type: (AdapterSpec, bool) -> None
+    def __init__(self, adapter, testnet=False, local_pow=False):
+        # type: (AdapterSpec, bool, bool) -> None
         """
         :param adapter:
             URI string or BaseAdapter instance.
@@ -82,6 +82,17 @@ class StrictIota(object):
             adapter = resolve_adapter(adapter)
 
         self.adapter = adapter  # type: BaseAdapter
+        # Note that the `local_pow` parameter is passed to adapter,
+        # the api class has no notion about it. The reason being,
+        # that this parameter is used in `AttachToTangeCommand` calls,
+        # that is called from various api calls (`attach_to_tangle`,
+        # `send_trytes` or `send_transfer`). Inside `AttachToTangeCommand`,
+        # we no longer have access to the attributes of the API class, therefore
+        # `local_pow` needs to be associated with the adapter.
+        # Logically, `local_pow` will decide if the api call does pow
+        # via pyota-pow extension, or sends the request to a node.
+        # But technically, the parameter belongs to the adapter.
+        self.adapter.set_local_pow(local_pow)
         self.testnet = testnet
 
     def __getattr__(self, command):
@@ -138,6 +149,18 @@ class StrictIota(object):
             The name of the command to create.
         """
         return CustomCommand(self.adapter, command)
+
+    def set_local_pow(self, local_pow):
+        # type: (bool) -> None
+        """
+        Sets the local_pow attribute of the adapter of the api instance.
+        If it is true, attach_to_tangle command calls external interface
+        to perform pow, instead of sending the request to a node.
+        By default, it is set to false.
+        This particular method is needed if one wants to change
+        local_pow behavior dynamically.
+        """
+        self.adapter.set_local_pow(local_pow)
 
     @property
     def default_min_weight_magnitude(self):
@@ -527,8 +550,8 @@ class Iota(StrictIota):
     """
     commands = discover_commands('iota.commands.extended')
 
-    def __init__(self, adapter, seed=None, testnet=False):
-        # type: (AdapterSpec, Optional[TrytesCompatible], bool) -> None
+    def __init__(self, adapter, seed=None, testnet=False, local_pow=False):
+        # type: (AdapterSpec, Optional[TrytesCompatible], bool, bool) -> None
         """
         :param seed:
             Seed used to generate new addresses.
@@ -537,7 +560,7 @@ class Iota(StrictIota):
             .. note::
                 This value is never transferred to the node/network.
         """
-        super(Iota, self).__init__(adapter, testnet)
+        super(Iota, self).__init__(adapter, testnet, local_pow)
 
         self.seed = Seed(seed) if seed else Seed.random()
         self.helpers = Helpers(self)

--- a/iota/commands/core/attach_to_tangle.py
+++ b/iota/commands/core/attach_to_tangle.py
@@ -27,6 +27,18 @@ class AttachToTangleCommand(FilterCommand):
     def get_response_filter(self):
         return AttachToTangleResponseFilter()
 
+    def _execute(self, request):
+        if self.adapter.local_pow is True:
+            from pow import ccurl_interface
+            powed_trytes = ccurl_interface.attach_to_tangle(
+                request['trytes'],
+                request['branchTransaction'],
+                request['trunkTransaction'],
+                request['minWeightMagnitude']
+            )
+            return {'trytes': powed_trytes}
+        else:
+            return super(FilterCommand, self)._execute(request)
 
 class AttachToTangleRequestFilter(RequestFilter):
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setuptools.setup(
 
     extras_require={
         'ccurl': ['pyota-ccurl'],
+        'pow': ['pyota-pow >= 1.0.1'],
         'docs-builder': ['sphinx', 'sphinx_rtd_theme'],
         # tox is able to run the tests in parallel since version 3.7
         'test-runner': ['tox >= 3.7'] + tests_require,

--- a/test/local_pow_test.py
+++ b/test/local_pow_test.py
@@ -8,8 +8,12 @@ from iota.adapter.sandbox import SandboxAdapter
 from iota.adapter.wrappers import RoutingWrapper
 from unittest import TestCase
 import sys
+from six import PY2
 
-from unittest.mock import MagicMock, patch
+if PY2:
+    from mock import MagicMock, patch
+else:
+    from unittest.mock import MagicMock, patch
 
 # Load mocked package on import from pow pkg.
 # Therefore we can test without having to install it.

--- a/test/local_pow_test.py
+++ b/test/local_pow_test.py
@@ -81,7 +81,7 @@ class LocalPowTestCase(TestCase):
         Test if local_pow feature works with HttpAdapter.
         """
         # Note that we need correct return value to pass the
-        # repsonse filter.
+        # response filter.
         with patch('pow.ccurl_interface.attach_to_tangle',
                     MagicMock(return_value=self.bundle)) as mocked_ccurl:
             api = Iota(HttpAdapter('http://localhost:14265/'),local_pow=True)
@@ -98,7 +98,7 @@ class LocalPowTestCase(TestCase):
         Test if local_pow feature works with MockAdapter.
         """
         # Note that we need correct return value to pass the
-        # repsonse filter.
+        # response filter.
         with patch('pow.ccurl_interface.attach_to_tangle',
                     MagicMock(return_value=self.bundle)) as mocked_ccurl:
             api = Iota(MockAdapter(),local_pow=True)
@@ -115,7 +115,7 @@ class LocalPowTestCase(TestCase):
         Test if local_pow feature works with SandboxAdapter.
         """
         # Note that we need correct return value to pass the
-        # repsonse filter.
+        # response filter.
         with patch('pow.ccurl_interface.attach_to_tangle',
                     MagicMock(return_value=self.bundle)) as mocked_ccurl:
             api = Iota(SandboxAdapter('https://sandbox.iota:14265/api/v1/', auth_token=None),
@@ -133,7 +133,7 @@ class LocalPowTestCase(TestCase):
         Test if local_pow feature works with RoutingWrapper.
         """
         # Note that we need correct return value to pass the
-        # repsonse filter.
+        # response filter.
         with patch('pow.ccurl_interface.attach_to_tangle',
                     MagicMock(return_value=self.bundle)) as mocked_ccurl:
             # We are trying to redirect `attach_to_tangle` calls to localhost
@@ -190,8 +190,3 @@ class LocalPowTestCase(TestCase):
             self.assertEqual(result['trytes'], self.bundle)
             # And not by mocked pow pkg
             self.assertNotEqual(result['trytes'], self.ccurl_bundle)
-
-
-
-
-

--- a/test/local_pow_test.py
+++ b/test/local_pow_test.py
@@ -1,0 +1,193 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, \
+  unicode_literals
+
+from iota import Iota, TryteString, TransactionHash, TransactionTrytes, \
+    HttpAdapter, MockAdapter
+from iota.adapter.sandbox import SandboxAdapter
+from iota.adapter.wrappers import RoutingWrapper
+from unittest import TestCase
+import sys
+
+from unittest.mock import MagicMock, patch
+
+# Load mocked package on import from pow pkg.
+# Therefore we can test without having to install it.
+sys.modules['pow'] = MagicMock()
+
+class LocalPowTestCase(TestCase):
+    """
+    Unit tests for `local_pow` feature using `pow` package
+    from `ccurl.inteface.py`.
+    """
+    # We are only interested in if the ccurl interface is called.
+    # Don't care about the values, and there is no actual PoW
+    # calculation in these tests. Testing the functional correctness
+    # of the PoW calculation is done in iotaledger/ccurl.interface.py.
+    # Filters are thoroughly tested in `attach_to_tangle_test.py`.
+    def setUp(self):
+        """
+        These values will be used in the tests. 
+        """
+        # Will be padded to transaction length by TransactionTrytes()
+        self.trytes1 ='CCLDVADBEACCWCTCEAZBCDFCE'
+        # Will be padded to transaction length by TransactionTrytes()
+        self.trytes2 ='CGDEAHDFDPCBDGDPCRCHDXCCDBDEAKDPC'
+        # Will be padded to hash length by TransactionHash()
+        self.trunk ='EWSQPV9AGXUQRYAZIUONVBXFNWRWIGVCFT'
+        self.branch ='W9VELHQPPERYSG9ZLLAHQKDLJQBKYYZOS'
+        self.mwm = 14
+
+        # Create real objects so that we pass the filters
+        self.bundle = [TransactionTrytes(self.trytes1), TransactionTrytes(self.trytes2)]
+        # ccurl_bundle is only needed to differentiate between response
+        # from mocked pow and MockAdapter in some test cases.
+        self.ccurl_bundle = [TransactionTrytes(self.trytes1)]
+        self.trunk = TransactionHash(self.trunk)
+        self.branch = TransactionHash(self.branch)
+    
+    def test_backward_compatibility(self):
+        """
+        Test that the local_pow feature is backward compatible.
+        That is, if `local_pow` argument is omitted, it takes no
+        effect and the pow extension package is not called.
+        """
+        with patch('pow.ccurl_interface.attach_to_tangle',
+                   MagicMock(return_value=self.ccurl_bundle)) as mocked_ccurl:
+            self.adapter = MockAdapter()
+            self.adapter.seed_response('attachToTangle',{
+                'trytes': self.bundle,
+            })
+            # No `local_pow` argument is passed to the api!
+            api = Iota(self.adapter)
+            result = api.attach_to_tangle(
+                self.trunk,
+                self.branch,
+                self.bundle,
+                self.mwm)
+            # Ccurl interface was not called
+            self.assertFalse(mocked_ccurl.called)
+            # Result is the one returned by MockAdapter
+            self.assertEqual(result['trytes'], self.bundle)
+            # And not by mocked pow pkg
+            self.assertNotEqual(result['trytes'], self.ccurl_bundle)
+
+    def test_http_adapter(self):
+        """
+        Test if local_pow feature works with HttpAdapter.
+        """
+        # Note that we need correct return value to pass the
+        # repsonse filter.
+        with patch('pow.ccurl_interface.attach_to_tangle',
+                    MagicMock(return_value=self.bundle)) as mocked_ccurl:
+            api = Iota(HttpAdapter('http://localhost:14265/'),local_pow=True)
+            result = api.attach_to_tangle(
+                self.trunk,
+                self.branch,
+                self.bundle,
+                self.mwm)
+            self.assertTrue(mocked_ccurl.called)
+            self.assertEqual(result['trytes'], self.bundle)
+
+    def test_mock_adapter(self):
+        """
+        Test if local_pow feature works with MockAdapter.
+        """
+        # Note that we need correct return value to pass the
+        # repsonse filter.
+        with patch('pow.ccurl_interface.attach_to_tangle',
+                    MagicMock(return_value=self.bundle)) as mocked_ccurl:
+            api = Iota(MockAdapter(),local_pow=True)
+            result = api.attach_to_tangle(
+                self.trunk,
+                self.branch,
+                self.bundle,
+                self.mwm)
+            self.assertTrue(mocked_ccurl.called)
+            self.assertEqual(result['trytes'], self.bundle)
+
+    def test_sandbox_adapter(self):
+        """
+        Test if local_pow feature works with SandboxAdapter.
+        """
+        # Note that we need correct return value to pass the
+        # repsonse filter.
+        with patch('pow.ccurl_interface.attach_to_tangle',
+                    MagicMock(return_value=self.bundle)) as mocked_ccurl:
+            api = Iota(SandboxAdapter('https://sandbox.iota:14265/api/v1/', auth_token=None),
+                       local_pow=True)
+            result = api.attach_to_tangle(
+                self.trunk,
+                self.branch,
+                self.bundle,
+                self.mwm)
+            self.assertTrue(mocked_ccurl.called)
+            self.assertEqual(result['trytes'], self.bundle)
+    
+    def test_routing_wrapper(self):
+        """
+        Test if local_pow feature works with RoutingWrapper.
+        """
+        # Note that we need correct return value to pass the
+        # repsonse filter.
+        with patch('pow.ccurl_interface.attach_to_tangle',
+                    MagicMock(return_value=self.bundle)) as mocked_ccurl:
+            # We are trying to redirect `attach_to_tangle` calls to localhost
+            # with a RoutingWrapper. However, if local_pow=true, the pow
+            # request will not reach the adapter, but will be directed to
+            # ccurl interface. 
+            api = Iota(RoutingWrapper('http://12.34.56.78:14265')
+                       .add_route('attachToTangle', 'http://localhost:14265'),
+                       local_pow=True)
+            result = api.attach_to_tangle(
+                self.trunk,
+                self.branch,
+                self.bundle,
+                self.mwm)
+            self.assertTrue(mocked_ccurl.called)
+            self.assertEqual(result['trytes'], self.bundle)
+    
+    def test_set_local_pow(self):
+        """
+        Test if local_pow can be enabled/disabled dynamically.
+        """
+        with patch('pow.ccurl_interface.attach_to_tangle',
+                   MagicMock(return_value=self.ccurl_bundle)) as mocked_ccurl:
+            self.adapter = MockAdapter()
+            self.adapter.seed_response('attachToTangle',{
+                'trytes': self.bundle,
+            })
+            # First, we enable local_pow
+            api = Iota(self.adapter, local_pow=True)
+            result = api.attach_to_tangle(
+                self.trunk,
+                self.branch,
+                self.bundle,
+                self.mwm)
+            # Ccurl was called
+            self.assertTrue(mocked_ccurl.called)
+            # Result comes from ccurl
+            self.assertEqual(result['trytes'], self.ccurl_bundle)
+
+            # Reset mock, this clears the called attribute
+            mocked_ccurl.reset_mock()
+
+            # Disable local_pow
+            api.set_local_pow(local_pow=False)
+            # Try again
+            result = api.attach_to_tangle(
+                self.trunk,
+                self.branch,
+                self.bundle,
+                self.mwm)
+            # Ccurl interface was not called
+            self.assertFalse(mocked_ccurl.called)
+            # Result is the one returned by MockAdapter
+            self.assertEqual(result['trytes'], self.bundle)
+            # And not by mocked pow pkg
+            self.assertNotEqual(result['trytes'], self.ccurl_bundle)
+
+
+
+
+


### PR DESCRIPTION
Related issues: #139 #228 

To perform PoW (attach_to_tangle) locally, BaseAdatper class has a new attribute, local_pow,
that is set to False by default (and therefore it is backward compatible). By declaring a new api instance with local_pow=True, attach_to_tangle calls will be handled by an interface to the ccurl library. The interface can be installed via an extension module to pyota:
```
pip install pyota[pow]
```
Or alternatively through following the steps in the README at:
https://github.com/lzpap/ccurl.interface.py

Or directly from PyPi:
```
pip install pyota-pow
```

~TODO: write tests~

Please share your thoughts about the change :) 