### PR TITLE
add_signature_or_message method for ProposedBundle

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -347,6 +347,10 @@ bundles, listed in the order that they should be invoked:
 -  ``send_unspent_inputs_to: (Address) -> None``: Specifies the address
    that will receive unspent IOTAs. The ``ProposedBundle`` will use this
    to create the necessary change transaction, if necessary.
+-  ``add_signature_or_message: (List[Fragment], int) -> None``:
+   Adds signature or message fragments to transactions in the bundle
+   starting from ``start_index``. Must be called before the bundle is
+   finalized.
 -  ``finalize: () -> None``: Prepares the bundle for PoW. Once this
    method is invoked, no new transactions may be added to the bundle.
 -  ``sign_inputs: (KeyGenerator) -> None``: Generates the necessary


### PR DESCRIPTION
Solves #253

### Description
The method can insert custom messages or signatures into transactions in a `ProposedBundle` object.

### Motivation
Ability to easily add custom messages to transactions after `ProposedBundle` creation.

### Additional Info
The test file is formatted with 2 space indentation to make review easier. In a future PR old test files will be converted to use 4 space indentation as per PEP-8.