### PR TITLE
Fine-tune is_promotable response dictionary

### DIFF
--- a/iota/api.py
+++ b/iota/api.py
@@ -1357,6 +1357,8 @@ class Iota(StrictIota):
                     'info': Optional(List[Text])
                         If `promotable` is ``False``, this contains info about what
                         went wrong.
+                        Note that when 'promotable' is ``True``, 'info' does not
+                        exist.
 
                 }
 

--- a/iota/commands/extended/is_promotable.py
+++ b/iota/commands/extended/is_promotable.py
@@ -93,8 +93,9 @@ class IsPromotableCommand(FilterCommand):
             response['promotable'] = response['promotable'] and is_within
 
         # If there are no problems, we don't need 'info' field
+        # Delete info field to make it consistent with check_consistency repsonse.
         if response['promotable']:
-            response['info'] = None
+            del response['info']
 
         return response
 

--- a/test/commands/extended/is_promotable_test.py
+++ b/test/commands/extended/is_promotable_test.py
@@ -317,7 +317,6 @@ class IsPromotableCommandTestCase(TestCase):
 
                 {
                     'promotable': True,
-                    'info': None,
                 }
             )
 


### PR DESCRIPTION
## Solves #262

## Changes
Make the ``is_promotable`` extended API method response ``dict`` consistent with ``check_consistency`` API method. Delete ``'info'`` key in response if ``'promotable'`` is ``True``.