### PR TITLE
docs: re-write PyOTA types page

### DIFF
--- a/docs/basic_concepts.rst
+++ b/docs/basic_concepts.rst
@@ -140,8 +140,8 @@ field that is a `unique identifier for the bundle`_.
    :alt: Bundle structure with four transactions.
 
    Structure of a bundle with four transactions. Numbers in brackets denote
-   (``currentIndex``, ``lastIndex``) fields. Head of the bundle has index 0,
-   while tail has index 3.
+   (``currentIndex``, ``lastIndex``) fields. Head of the bundle has index 3,
+   while tail has index 0.
 
 Read more about `how bundles are structured`_.
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -4,74 +4,75 @@ PyOTA Types
 PyOTA defines a few types that will make it easy for you to model
 objects like Transactions and Bundles in your own code.
 
+Since everything in IOTA is represented as a sequence of ``trits`` and ``trytes``,
+let us take a look on how you can work with them in PyOTA.
+
 TryteString
 -----------
+.. py:currentmodule:: iota
+
+.. autoclass:: TryteString
+
+Example usage:
 
 .. code:: python
 
     from iota import TryteString
 
+    # Create a TryteString object from bytes.
     trytes_1 = TryteString(b'RBTC9D9DCDQAEASBYBCCKBFA')
-    trytes_2 = TryteString(b'LH9GYEMHCF9GWHZFEELHVFOEOHNEEEWHZFUD')
 
+    # Ensure the created object is 81 trytes long by padding it with zeros.
+    # The value zero is represented with character '9' in trytes.
+    trytes_1 = TryteString(b'RBTC9D9DCDQAEASBYBCCKBFA', pad=81)
+
+    # Create a TryteString object from text type.
+    # Note that this will throw error if text contains unsupported characters.
+    trytes_2 = TryteString('LH9GYEMHCF9GWHZFEELHVFOEOHNEEEWHZFUD')
+
+    # Comparison and concatenation:
     if trytes_1 != trytes_2:
       trytes_combined = trytes_1 + trytes_2
 
+    # As dictionary keys:
     index = {
       trytes_1: 42,
       trytes_2: 86,
     }
 
-A ``TryteString`` is an ASCII representation of a sequence of trytes. In
-many respects, it is similar to a Python ``bytes`` object (which is an
-ASCII representation of a sequence of bytes).
-
-In fact, the two objects behave very similarly; they support
-concatenation, comparison, can be used as dict keys, etc.
-
-However, unlike ``bytes``, a ``TryteString`` can only contain uppercase
-letters and the number 9 (as a regular expression: ``^[A-Z9]*$``).
-
 As you go through the API documentation, you will see many references to
-``TryteString`` and its subclasses:
+:py:class:`TryteString` and its subclasses:
 
--  ``Fragment``: A signature or message fragment inside a transaction.
+-  :py:class:`Fragment`: A signature or message fragment inside a transaction.
    Fragments are always 2187 trytes long.
--  ``Hash``: An object identifier. Hashes are always 81 trytes long.
+-  :py:class:`Hash`: An object identifier. Hashes are always 81 trytes long.
    There are many different types of hashes:
--  ``Address``: Identifies an address on the Tangle.
--  ``BundleHash``: Identifies a bundle on the Tangle.
--  ``TransactionHash``: Identifies a transaction on the Tangle.
--  ``Seed``: A TryteString that is used for crypto functions such as
+-  :py:class:`Address`: Identifies an address on the Tangle.
+-  :py:class:`BundleHash`: Identifies a bundle on the Tangle.
+-  :py:class:`TransactionHash`: Identifies a transaction on the Tangle.
+-  :py:class:`Seed`: A TryteString that is used for crypto functions such as
    generating addresses, signing inputs, etc. Seeds can be any length,
    but 81 trytes offers the best security.
--  ``Tag``: A tag used to classify a transaction. Tags are always 27
+-  :py:class:`Tag`: A tag used to classify a transaction. Tags are always 27
    trytes long.
--  ``TransactionTrytes``: A TryteString representation of a transaction
+-  :py:class:`TransactionTrytes`: A TryteString representation of a transaction
    on the Tangle. ``TransactionTrytes`` are always 2673 trytes long.
+
+Let's explore the capabilities of the :py:class:`TryteString` base class.
 
 Encoding
 ~~~~~~~~
 
-.. code:: python
+You may use classmethods to create a :py:class:`TryteString` from ``bytes``,
+``unicode string`` or from a list of ``trits``.
 
-    from iota import TryteString
+**from_bytes**
+^^^^^^^^^^^^^^
+.. automethod:: TryteString.from_bytes
 
-    message_trytes = TryteString.from_unicode('Hello, IOTA!')
-
-To encode character data into trytes, use the
-``TryteString.from_unicode`` method.
-
-You can also convert a tryte sequence into characters using
-``TryteString.decode``. Note that not every tryte sequence can be
-converted; garbage in, garbage out!
-
-.. code:: python
-
-    from iota import TryteString
-
-    trytes = TryteString(b'RBTC9D9DCDQAEASBYBCCKBFA')
-    message = trytes.decode()
+**from_unicode**
+^^^^^^^^^^^^^^^^
+.. automethod:: TryteString.from_unicode
 
 .. note::
 
@@ -83,205 +84,269 @@ converted; garbage in, garbage out!
     use ASCII characters when generating ``TryteString`` objects from
     character strings.
 
+**from_trits**
+^^^^^^^^^^^^^^
+.. automethod:: TryteString.from_trits
+
+**from_trytes**
+^^^^^^^^^^^^^^^
+.. automethod:: TryteString.from_trytes
+
+Additionally, you can encode a :py:class:`TryteString` into a lower-level
+primitive (usually bytes). This might be useful when the :py:class:`TryteString`
+contains ASCII encoded characters but you need it as ``bytes``. See the example
+below:
+
+**encode**
+^^^^^^^^^^
+.. automethod:: TryteString.encode
+
+
+Decoding
+~~~~~~~~
+
+You can also convert a tryte sequence into characters using
+:py:meth:`TryteString.decode`. Note that not every tryte sequence can be
+converted; garbage in, garbage out!
+
+**decode**
+^^^^^^^^^^
+.. automethod:: TryteString.decode
+
+**as_json_compatible**
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: TryteString.as_json_compatible
+
+**as_integers**
+^^^^^^^^^^^^^^^
+.. automethod:: TryteString.as_integers
+
+**as_trytes**
+^^^^^^^^^^^^^
+.. automethod:: TryteString.as_trytes
+
+**as_trits**
+^^^^^^^^^^^^
+.. automethod:: TryteString.as_trits
+
+Seed
+----
+.. autoclass:: Seed
+
+**random**
+~~~~~~~~~~
+.. automethod:: Seed.random
+
+Address
+-------
+.. autoclass:: Address
+  :members: address, balance, key_index, security_level
+
+**as_json_compatible**
+~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: Address.as_json_compatible
+
+**is_checksum_valid**
+~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: Address.is_checksum_valid
+
+**with_valid_checksum**
+~~~~~~~~~~~~~~~~~~~~~~~
+.. automethod:: Address.with_valid_checksum
+
+**add_checksum**
+~~~~~~~~~~~~~~~~
+.. automethod:: Address.add_checksum
+
+**remove_checksum**
+~~~~~~~~~~~~~~~~~~~
+.. automethod:: Address.remove_checksum
+
+AddressChecksum
+---------------
+.. autoclass:: AddressChecksum
+  :members:
+
+Hash
+----
+.. autoclass:: Hash
+  :members:
+
+TransactionHash
+---------------
+.. autoclass:: TransactionHash
+  :members:
+
+BundleHash
+----------
+.. autoclass:: BundleHash
+  :members:
+
+TransactionTrytes
+-----------------
+.. autoclass:: TransactionTrytes
+  :members:
+
+Fragment
+--------
+.. autoclass:: Fragment
+  :members:
+
+Nonce
+-----
+.. autoclass:: Nonce
+  :members:
+
+Tag
+---
+.. autoclass:: Tag
+  :members:
+
 Transaction Types
 -----------------
 
 PyOTA defines two different types used to represent transactions:
 
+ - :py:class:`Transaction` for transactions that have already been
+   attached to the Tangle. Generally, you will never need to create
+   :py:class:`Transaction` objects; the API will build them for you,
+   as the result of various API methods.
+ - :py:class:`ProposedTransaction` for transactions that have been created
+   locally and have not been broadcast yet.
+
 Transaction
 ~~~~~~~~~~~
+Each :py:class:`Transaction` object has several instance attributes that you
+may manipulate and properties you can use to extract their values as trytes.
+See the class documentation below:
 
-.. code:: python
+.. autoclass:: Transaction
+  :members: hash, bundle_hash, address, value, nonce, timestamp,
+    current_index, last_index, trunk_transaction_hash, branch_transaction_hash,
+    tag, attachment_timestamp, attachment_timestamp_lower_bound,
+    attachment_timestamp_upper_bound, signature_message_fragment, is_confirmed,
+    is_tail, value_as_trytes, timestamp_as_trytes, current_index_as_trytes,
+    last_index_as_trytes, attachment_timestamp_as_trytes,
+    attachment_timestamp_lower_bound_as_trytes,
+    attachment_timestamp_upper_bound_as_trytes, legacy_tag
 
-    from iota import Address, ProposedTransaction, Tag, Transaction
+**as_json_compatible**
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: Transaction.as_json_compatible
 
-    txn_1 =\
-      Transaction.from_tryte_string(
-        b'GYPRVHBEZOOFXSHQBLCYW9ICTCISLHDBNMMVYD9JJHQMPQCTIQAQTJNNNJ9IDXLRCC'
-        b'OYOXYPCLR9PBEY9ORZIEPPDNTI9CQWYZUOTAVBXPSBOFEQAPFLWXSWUIUSJMSJIIIZ'
-        b'WIKIRH9GCOEVZFKNXEVCUCIIWZQCQEUVRZOCMEL9AMGXJNMLJCIA9UWGRPPHCEOPTS'
-        b'VPKPPPCMQXYBHMSODTWUOABPKWFFFQJHCBVYXLHEWPD9YUDFTGNCYAKQKVEZYRBQRB'
-        b'XIAUX9SVEDUKGMTWQIYXRGSWYRK9SRONVGTW9YGHSZRIXWGPCCUCDRMAXBPDFVHSRY'
-        b'WHGB9DQSQFQKSNICGPIPTRZINYRXQAFSWSEWIFRMSBMGTNYPRWFSOIIWWT9IDSELM9'
-        b'JUOOWFNCCSHUSMGNROBFJX9JQ9XT9PKEGQYQAWAFPRVRRVQPUQBHLSNTEFCDKBWRCD'
-        b'X9EYOBB9KPMTLNNQLADBDLZPRVBCKVCYQEOLARJYAGTBFR9QLPKZBOYWZQOVKCVYRG'
-        b'YI9ZEFIQRKYXLJBZJDBJDJVQZCGYQMROVHNDBLGNLQODPUXFNTADDVYNZJUVPGB9LV'
-        b'PJIYLAPBOEHPMRWUIAJXVQOEM9ROEYUOTNLXVVQEYRQWDTQGDLEYFIYNDPRAIXOZEB'
-        b'CS9P99AZTQQLKEILEVXMSHBIDHLXKUOMMNFKPYHONKEYDCHMUNTTNRYVMMEYHPGASP'
-        b'ZXASKRUPWQSHDMU9VPS99ZZ9SJJYFUJFFMFORBYDILBXCAVJDPDFHTTTIYOVGLRDYR'
-        b'TKHXJORJVYRPTDH9ZCPZ9ZADXZFRSFPIQKWLBRNTWJHXTOAUOL9FVGTUMMPYGYICJD'
-        b'XMOESEVDJWLMCVTJLPIEKBE9JTHDQWV9MRMEWFLPWGJFLUXI9BXPSVWCMUWLZSEWHB'
-        b'DZKXOLYNOZAPOYLQVZAQMOHGTTQEUAOVKVRRGAHNGPUEKHFVPVCOYSJAWHZU9DRROH'
-        b'BETBAFTATVAUGOEGCAYUXACLSSHHVYDHMDGJP9AUCLWLNTFEVGQGHQXSKEMVOVSKQE'
-        b'EWHWZUDTYOBGCURRZSJZLFVQQAAYQO9TRLFFN9HTDQXBSPPJYXMNGLLBHOMNVXNOWE'
-        b'IDMJVCLLDFHBDONQJCJVLBLCSMDOUQCKKCQJMGTSTHBXPXAMLMSXRIPUBMBAWBFNLH'
-        b'LUJTRJLDERLZFUBUSMF999XNHLEEXEENQJNOFFPNPQ9PQICHSATPLZVMVIWLRTKYPI'
-        b'XNFGYWOJSQDAXGFHKZPFLPXQEHCYEAGTIWIJEZTAVLNUMAFWGGLXMBNUQTOFCNLJTC'
-        b'DMWVVZGVBSEBCPFSM99FLOIDTCLUGPSEDLOKZUAEVBLWNMODGZBWOVQT9DPFOTSKRA'
-        b'BQAVOQ9RXWBMAKFYNDCZOJGTCIDMQSQQSODKDXTPFLNOKSIZEOY9HFUTLQRXQMEPGO'
-        b'XQGLLPNSXAUCYPGZMNWMQWSWCKAQYKXJTWINSGPPZG9HLDLEAWUWEVCTVRCBDFOXKU'
-        b'ROXH9HXXAXVPEJFRSLOGRVGYZASTEBAQNXJJROCYRTDPYFUIQJVDHAKEG9YACV9HCP'
-        b'JUEUKOYFNWDXCCJBIFQKYOXGRDHVTHEQUMHO999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999999999999999999999999999999999999'
-        b'999999999999RKWEEVD99A99999999A99999999NFDPEEZCWVYLKZGSLCQNOFUSENI'
-        b'XRHWWTZFBXMPSQHEDFWZULBZFEOMNLRNIDQKDNNIELAOXOVMYEI9PGTKORV9IKTJZQ'
-        b'UBQAWTKBKZ9NEZHBFIMCLV9TTNJNQZUIJDFPTTCTKBJRHAITVSKUCUEMD9M9SQJ999'
-        b'999TKORV9IKTJZQUBQAWTKBKZ9NEZHBFIMCLV9TTNJNQZUIJDFPTTCTKBJRHAITVSK'
-        b'UCUEMD9M9SQJ999999999999999999999999999999999999999999999999999999'
-        b'999999999999999999999999999999999'
-      )
+**as_tryte_string**
+^^^^^^^^^^^^^^^^^^^
+.. automethod:: Transaction.as_tryte_string
 
-``Transaction`` is a transaction that has been loaded from the Tangle.
+**from_tryte_string**
+^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: Transaction.from_tryte_string
 
-Generally, you will never need to create ``Transaction`` objects; the
-API will build them for you, as the result of various API methods.
-
-Each ``Transaction`` has the following attributes:
-
--  ``address: Address``: The address associated with this transaction.
-   Depending on the transaction's ``value``, this address may be a
-   sender or a recipient.
--  ``attachment_timestamp: int``: Estimated epoch time of the attachment to the tangle.
--  ``attachment_time_lower_bound: int``: The lowest possible epoch time of the attachment to the tangle.
--  ``attachment_time_upper_bound: int``: The highest possible epoch time of the attachment to the tangle.
--  ``branch_transaction_hash: TransactionHash``: An unrelated
-   transaction that this transaction "approves". Refer to the Basic
-   Concepts section for more information.
--  ``bundle_hash: BundleHash``: The bundle hash, used to identify
-   transactions that are part of the same bundle. This value is
-   generated by taking a hash of the metadata from all transactions in
-   the bundle.
--  ``current_index: int``: The transaction's position in the bundle.
--  If the ``current_index`` value is 0, then this is the "tail
-   transaction".
--  If it is equal to ``last_index``, then this is the "head
-   transaction".
--  ``hash: TransactionHash``: The transaction hash, used to uniquely
-   identify the transaction on the Tangle. This value is generated by
-   taking a hash of the raw transaction trits.
--  ``is_confirmed: Optional[bool]``: Whether this transaction has been
-   "confirmed". Refer to the Basic Concepts section for more
-   information.
--  ``last_index: int``: The index of the final transaction in the
-   bundle. This value is attached to every transaction to make it easier
-   to traverse and verify bundles.
--  ``legacy_tag: Tag``: A short message attached to the transaction. Deprecated, use ``tag`` instead.
--  ``nonce: Hash``: This is the product of the PoW process.
--  ``signature_message_fragment: Fragment``: Additional data attached to
-   the transaction:
--  If ``value < 0``, this value contains a fragment of the cryptographic
-   signature authorizing the spending of the IOTAs.
--  If ``value > 0``, this value is an (optional) string message attached
-   to the transaction.
--  If ``value = 0``, this value could be either a signature or message
-   fragment, depending on the previous transaction.
--  ``tag: Tag``: Used to classify the transaction. Many transactions
-   have empty tags (``Tag(b'999999999999999999999999999')``).
--  ``timestamp: int``: Unix timestamp when the transaction was created.
-   Note that devices can specify any timestamp when creating
-   transactions, so this value is not safe to use for security measures
-   (such as resolving double-spends).
--  ``trunk_transaction_hash: TransactionHash``: The transaction hash of
-   the next transaction in the bundle. If this transaction is the head
-   transaction, its ``trunk_transaction_hash`` will be pseudo-randomly
-   selected, similarly to ``branch_transaction_hash``.
--  ``value: int``: The number of IOTAs being transferred in this
-   transaction:
--  If this value is negative, then the ``address`` is spending IOTAs.
--  If it is positive, then the ``address`` is receiving IOTAs.
--  If it is zero, then this transaction is being used to carry metadata
-   (such as a signature fragment or a message) instead of transferring
-   IOTAs.
+**get_signature_validation_trytes**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: Transaction.get_signature_validation_trytes
 
 ProposedTransaction
 ~~~~~~~~~~~~~~~~~~~
 
-``ProposedTransaction`` is a transaction that was created locally and
-hasn't been broadcast yet.
+.. autoclass:: ProposedTransaction
 
-.. code:: python
+**as_tryte_string**
+^^^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedTransaction.as_tryte_string
 
-    txn_2 =\
-      ProposedTransaction(
-        address =
-          Address(
-            b'TESTVALUE9DONTUSEINPRODUCTION99999XE9IVG'
-            b'EFNDOCQCMERGUATCIEGGOHPHGFIAQEZGNHQ9W99CH'
-          ),
-
-        message = TryteString.from_unicode('thx fur cheezburgers'),
-        tag     = Tag(b'KITTEHS'),
-        value   = 42,
-      )
-
-This type is useful when creating new transactions to broadcast to the
-Tangle. Note that creating a ``ProposedTransaction`` requires only a
-small subset of the attributes needed to create a ``Transaction``
-object.
-
-To create a ``ProposedTransaction``, specify the following values:
-
--  ``address: Address``: The address associated with the transaction.
-   Note that each transaction references exactly one address; in order
-   to transfer IOTAs from one address to another, you must create at
-   least two transactions: One to deduct the IOTAs from the sender's
-   balance, and one to add the IOTAs to the recipient's balance.
--  ``message: Optional[TryteString]``: Optional trytes to attach to the
-   transaction. This could be any value (character strings, binary data,
-   or raw trytes), as long as it's converted to a ``TryteString`` first.
--  ``tag: Optional[Tag]``: Optional tag to classify this transaction.
-   Each transaction may have exactly one tag, and the tag is limited to
-   27 trytes.
--  ``value: int``: The number of IOTAs being transferred in this
-   transaction. This value can be 0; for example, to send a message
-   without spending any IOTAs.
+**increment_legacy_tag**
+^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedTransaction.increment_legacy_tag
 
 Bundle Types
 ------------
 
-As with transactions, PyOTA defines two bundle types.
+As with transactions, PyOTA defines two different types to represent bundles:
+
+ - :py:class:`Bundle` for bundles that have already been
+   broadcast to the Tangle. Generally, you will never need to create
+   :py:class:`Bundle` objects; the API will build them for you,
+   as the result of various API methods.
+ - :py:class:`ProposedBundle` for bundles that have been created
+   locally and have not been broadcast yet.
 
 Bundle
 ~~~~~~
 
-.. code:: python
+.. autoclass:: Bundle
+  :members: is_confirmed, hash, tail_transaction, transactions
 
-    from iota import Bundle
+**as_json_compatible**
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: Bundle.as_json_compatible
 
-    bundle = Bundle.from_tryte_strings([
-      b'GYPRVHBEZOOFXSHQBLCYW9ICTCISLHDBNMMVYD9JJHQMPQCTIQAQTJNNNJ9IDXLRCC...',
-      b'OYOXYPCLR9PBEY9ORZIEPPDNTI9CQWYZUOTAVBXPSBOFEQAPFLWXSWUIUSJMSJIIIZ...',
-      # etc.
-    ])
+**as_tryte_strings**
+^^^^^^^^^^^^^^^^^^^^
+.. automethod:: Bundle.as_tryte_strings
 
-``Bundle`` represents a bundle of transactions published on the Tangle.
-It is intended to be a read-only object, allowing you to inspect the
-transactions and bundle metadata.
+**from_tryte_strings**
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: Bundle.from_tryte_strings
 
-Each bundle has the following attributes:
+**get_messages**
+^^^^^^^^^^^^^^^^
+.. automethod:: Bundle.get_messages
 
--  ``hash: BundleHash``: The hash of this bundle. This value is
-   generated by taking a hash of the metadata from all transactions in
-   the bundle.
--  ``is_confirmed: Optional[bool]``: Whether the transactions in this
-   bundle have been confirmed. Refer to the Basic Concepts section for
-   more information.
--  ``tail_transaction: Optional[Transaction]``: The bundle's tail
-   transaction.
--  ``transactions: List[Transaction]``: The transactions associated with
-   this bundle.
+**group_transactions**
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: Bundle.group_transactions
 
 ProposedBundle
 ~~~~~~~~~~~~~~
+.. note::
+  This section contains information about how PyOTA works "under the
+  hood".
+
+  The :py:meth:`Iota.prepare_transfer` API method encapsulates this
+  functionality for you; it is not necessary to understand how
+  :py:class:`ProposedBundle` works in order to use PyOTA.
+
+.. autoclass:: ProposedBundle
+  :members: balance, tag
+
+:py:class:`ProposedBundle` provides a convenient interface for creating new
+bundles, listed in the order that they should be invoked:
+
+**add_transaction**
+^^^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedBundle.add_transaction
+
+**add_inputs**
+^^^^^^^^^^^^^^
+.. automethod:: ProposedBundle.add_inputs
+
+**send_unspent_inputs_to**
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedBundle.send_unspent_inputs_to
+
+**add_signature_or_message**
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedBundle.add_signature_or_message
+
+**finalize**
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedBundle.finalize
+
+**sign_inputs**
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedBundle.sign_inputs
+
+**sign_input_at**
+^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedBundle.sign_input_at
+
+**as_json_compatible**
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: ProposedBundle.as_json_compatible
+
+**Example usage**
+^^^^^^^^^^^^^^^^^
 
 .. code:: python
 
@@ -315,41 +380,7 @@ ProposedBundle
     bundle.finalize()
     bundle.sign_inputs(KeyGenerator(b'SEED9GOES9HERE'))
 
-.. note::
-
-    This section contains information about how PyOTA works "under the
-    hood".
-
-        The ``prepare_transfer`` API method encapsulates this functionality
-        for you; it is not necessary to understand how ``ProposedBundle``
-        works in order to use PyOTA.
-
-
-``ProposedBundle`` provides a convenient interface for creating new
-bundles, listed in the order that they should be invoked:
-
--  ``add_transaction: (ProposedTransaction) -> None``: Adds a
-   transaction to the bundle. If necessary, it may split the transaction
-   into multiple (for example, if the transaction's message is too long
-   to fit into 2187 trytes).
--  ``add_inputs: (List[Address]) -> None``: Specifies inputs that can be
-   used to fund transactions that spend IOTAs. The ``ProposedBundle``
-   will use these to create the necessary input transactions.
--  You can use the ``get_inputs`` API command to find suitable inputs.
--  ``send_unspent_inputs_to: (Address) -> None``: Specifies the address
-   that will receive unspent IOTAs. The ``ProposedBundle`` will use this
-   to create the necessary change transaction, if necessary.
--  ``add_signature_or_message: (List[Fragment], int) -> None``:
-   Adds signature or message fragments to transactions in the bundle
-   starting from ``start_index``. Must be called before the bundle is
-   finalized.
--  ``finalize: () -> None``: Prepares the bundle for PoW. Once this
-   method is invoked, no new transactions may be added to the bundle.
--  ``sign_inputs: (KeyGenerator) -> None``: Generates the necessary
-   cryptographic signatures to authorize spending the inputs. You do not
-   need to invoke this method if the bundle does not contain any
-   transactions that spend IOTAs.
-
-Once the ``ProposedBundle`` has been finalized (and inputs signed, if
-necessary), invoke its ``as_tryte_strings`` method to generate the raw
-trytes that should be included in an ``attach_to_tangle`` API request.
+Once the :py:class:`ProposedBundle` has been finalized (and inputs signed, if
+necessary), invoke its :py:meth:`ProposedBundle.as_tryte_strings` method to
+generate the raw trytes that should be included in an
+:py:meth:`Iota.attach_to_tangle` API request.

--- a/iota/__init__.py
+++ b/iota/__init__.py
@@ -38,6 +38,9 @@ from .adapter import *
 from .api import *
 from .trits import *
 
+# Expose Seed on the top level package
+from .crypto.types import Seed
+
 # :see: http://stackoverflow.com/a/2073599/
 from pkg_resources import require
 __version__ = require('PyOTA')[0].version

--- a/iota/crypto/addresses.py
+++ b/iota/crypto/addresses.py
@@ -26,6 +26,24 @@ class AddressGenerator(Iterable[Address]):
     Note also that :py:meth:`iota.api.IotaApi.get_new_addresses` uses
     ``AddressGenerator`` internally, so you get the best of both worlds
     when you use the API (:
+
+    :param TrytesCompatible seed:
+        The seed to derive addresses from.
+
+    :param int security_level:
+        When generating a new address, you can specify a security level for it.
+        The security level of an address affects how long the private key is,
+        how secure a spent address is against brute-force attacks, and how many
+        transactions are needed to contain the signature.
+
+        Could be either 1, 2 or 3.
+
+        Reference:
+
+        - https://docs.iota.org/docs/getting-started/0.1/clients/security-levels
+
+    :param bool checksum:
+        Whether to generate address with or without checksum.
     """
     DEFAULT_SECURITY_LEVEL = 2
     """
@@ -90,6 +108,8 @@ class AddressGenerator(Iterable[Address]):
             This may be any non-zero (positive or negative) integer.
 
         :return:
+            ``List[Address]``
+
             Always returns a list, even if only one address is generated.
 
             The returned list will contain ``count`` addresses, except

--- a/iota/transaction/base.py
+++ b/iota/transaction/base.py
@@ -23,6 +23,60 @@ __all__ = [
 class Transaction(JsonSerializable):
     """
     A transaction that has been attached to the Tangle.
+
+    :param Optional[TransactionHash] hash_:
+        Transaction ID
+
+    :param Optional[Fragment] signature_message_fragment:
+        Signature or message fragment.
+
+    :param Address address:
+        The address associated with this transaction.
+
+    :param int value:
+        Value of the transaction in iotas. Can be negative as well
+        (spending from address).
+
+    :param int timestamp:
+        Unix timestamp in seconds.
+
+    :param Optional[int] current_index:
+        Index of the transaction within the bundle.
+
+    :param Optional[int] last_index:
+        Index of head transaction in the bundle.
+
+    :param Optional[BundleHash] bundle_hash:
+        Bundle hash of the bundle containing the transaction.
+
+    :param Optional[TransactionHash] trunk_transaction_hash:
+        Hash of trunk transaction.
+
+    :param Optional[TransactionHash] branch_transaction_hash:
+        Hash of branch transaction.
+
+    :param Optional[Tag] tag:
+        Optional classification tag applied to this transaction.
+
+    :param Optional[int] attachment_timestamp:
+        Unix timestamp in milliseconds, decribes when the proof-of-work for this
+        transaction was done.
+
+    :param Optional[int] attachment_timestamp_lower_bound:
+        Unix timestamp in milliseconds, lower bound of attachment.
+
+    :param Optional[int] attachment_timestamp_upper_bound:
+        Unix timestamp in milliseconds, upper bound of attachment.
+
+    :param Optional[Nonce] nonce:
+        Unique value used to increase security of the transaction hash. Result of
+        the proof-of-work aglorithm.
+
+    :param Optional[Tag] legacy_tag:
+        Optional classification legacy_tag applied to this transaction.
+
+    :return:
+        :py:class:`Transaction` object.
     """
 
     @classmethod
@@ -31,14 +85,67 @@ class Transaction(JsonSerializable):
         """
         Creates a Transaction object from a sequence of trytes.
 
-        :param trytes:
+        :param TrytesCompatible trytes:
             Raw trytes.  Should be exactly 2673 trytes long.
 
-        :param hash_:
+        :param Optional[TransactionHash] hash_:
             The transaction hash, if available.
 
             If not provided, it will be computed from the transaction
             trytes.
+
+        :return:
+            :py:class:`Transaction` object.
+
+        Example usage::
+
+            from iota import Transaction
+
+            txn =\\
+              Transaction.from_tryte_string(
+                b'GYPRVHBEZOOFXSHQBLCYW9ICTCISLHDBNMMVYD9JJHQMPQCTIQAQTJNNNJ9IDXLRCC'
+                b'OYOXYPCLR9PBEY9ORZIEPPDNTI9CQWYZUOTAVBXPSBOFEQAPFLWXSWUIUSJMSJIIIZ'
+                b'WIKIRH9GCOEVZFKNXEVCUCIIWZQCQEUVRZOCMEL9AMGXJNMLJCIA9UWGRPPHCEOPTS'
+                b'VPKPPPCMQXYBHMSODTWUOABPKWFFFQJHCBVYXLHEWPD9YUDFTGNCYAKQKVEZYRBQRB'
+                b'XIAUX9SVEDUKGMTWQIYXRGSWYRK9SRONVGTW9YGHSZRIXWGPCCUCDRMAXBPDFVHSRY'
+                b'WHGB9DQSQFQKSNICGPIPTRZINYRXQAFSWSEWIFRMSBMGTNYPRWFSOIIWWT9IDSELM9'
+                b'JUOOWFNCCSHUSMGNROBFJX9JQ9XT9PKEGQYQAWAFPRVRRVQPUQBHLSNTEFCDKBWRCD'
+                b'X9EYOBB9KPMTLNNQLADBDLZPRVBCKVCYQEOLARJYAGTBFR9QLPKZBOYWZQOVKCVYRG'
+                b'YI9ZEFIQRKYXLJBZJDBJDJVQZCGYQMROVHNDBLGNLQODPUXFNTADDVYNZJUVPGB9LV'
+                b'PJIYLAPBOEHPMRWUIAJXVQOEM9ROEYUOTNLXVVQEYRQWDTQGDLEYFIYNDPRAIXOZEB'
+                b'CS9P99AZTQQLKEILEVXMSHBIDHLXKUOMMNFKPYHONKEYDCHMUNTTNRYVMMEYHPGASP'
+                b'ZXASKRUPWQSHDMU9VPS99ZZ9SJJYFUJFFMFORBYDILBXCAVJDPDFHTTTIYOVGLRDYR'
+                b'TKHXJORJVYRPTDH9ZCPZ9ZADXZFRSFPIQKWLBRNTWJHXTOAUOL9FVGTUMMPYGYICJD'
+                b'XMOESEVDJWLMCVTJLPIEKBE9JTHDQWV9MRMEWFLPWGJFLUXI9BXPSVWCMUWLZSEWHB'
+                b'DZKXOLYNOZAPOYLQVZAQMOHGTTQEUAOVKVRRGAHNGPUEKHFVPVCOYSJAWHZU9DRROH'
+                b'BETBAFTATVAUGOEGCAYUXACLSSHHVYDHMDGJP9AUCLWLNTFEVGQGHQXSKEMVOVSKQE'
+                b'EWHWZUDTYOBGCURRZSJZLFVQQAAYQO9TRLFFN9HTDQXBSPPJYXMNGLLBHOMNVXNOWE'
+                b'IDMJVCLLDFHBDONQJCJVLBLCSMDOUQCKKCQJMGTSTHBXPXAMLMSXRIPUBMBAWBFNLH'
+                b'LUJTRJLDERLZFUBUSMF999XNHLEEXEENQJNOFFPNPQ9PQICHSATPLZVMVIWLRTKYPI'
+                b'XNFGYWOJSQDAXGFHKZPFLPXQEHCYEAGTIWIJEZTAVLNUMAFWGGLXMBNUQTOFCNLJTC'
+                b'DMWVVZGVBSEBCPFSM99FLOIDTCLUGPSEDLOKZUAEVBLWNMODGZBWOVQT9DPFOTSKRA'
+                b'BQAVOQ9RXWBMAKFYNDCZOJGTCIDMQSQQSODKDXTPFLNOKSIZEOY9HFUTLQRXQMEPGO'
+                b'XQGLLPNSXAUCYPGZMNWMQWSWCKAQYKXJTWINSGPPZG9HLDLEAWUWEVCTVRCBDFOXKU'
+                b'ROXH9HXXAXVPEJFRSLOGRVGYZASTEBAQNXJJROCYRTDPYFUIQJVDHAKEG9YACV9HCP'
+                b'JUEUKOYFNWDXCCJBIFQKYOXGRDHVTHEQUMHO999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999999999999999999999999999999999999'
+                b'999999999999RKWEEVD99A99999999A99999999NFDPEEZCWVYLKZGSLCQNOFUSENI'
+                b'XRHWWTZFBXMPSQHEDFWZULBZFEOMNLRNIDQKDNNIELAOXOVMYEI9PGTKORV9IKTJZQ'
+                b'UBQAWTKBKZ9NEZHBFIMCLV9TTNJNQZUIJDFPTTCTKBJRHAITVSKUCUEMD9M9SQJ999'
+                b'999TKORV9IKTJZQUBQAWTKBKZ9NEZHBFIMCLV9TTNJNQZUIJDFPTTCTKBJRHAITVSK'
+                b'UCUEMD9M9SQJ999999999999999999999999999999999999999999999999999999'
+                b'999999999999999999999999999999999'
+              )
+
         """
         tryte_string = TransactionTrytes(trytes)
 
@@ -98,75 +205,123 @@ class Transaction(JsonSerializable):
     ):
         self.hash = hash_
         """
-        Transaction ID, generated by taking a hash of the transaction
-        trits.
+        The transaction hash, used to uniquely identify the transaction on the
+        Tangle.
+
+        This value is generated by taking a hash of the raw transaction trits.
+
+        :type: :py:class:`TransactionHash`
         """
 
         self.bundle_hash = bundle_hash
         """
-        Bundle hash, generated by taking a hash of metadata from all the
+        The bundle hash, used to identify transactions that are part of the same
+        bundle.
+
+        This value is generated by taking a hash of the metadata from all
         transactions in the bundle.
+
+        :type: :py:class:`BundleHash`
         """
 
         self.address = address
         """
         The address associated with this transaction.
 
-        If ``value`` is != 0, the associated address' balance is
+        Depending on the transaction's ``value``, this address may be a sender
+        or a recipient. If ``value`` is != 0, the associated address' balance is
         adjusted as a result of this transaction.
+
+        :type: :py:class:`Address`
         """
 
         self.value = value
         """
-        Amount to adjust the balance of ``address``.
-        Can be negative (i.e., for spending inputs).
+        The number of iotas being transferred in this transaction:
+
+        - If this value is negative, then the ``address`` is spending iotas.
+        - If it is positive, then the ``address`` is receiving iotas.
+        - If it is zero, then this transaction is being used to carry metadata
+          (such as a signature fragment or a message) instead of transferring
+          iotas.
+
+        :type: ``int``
         """
 
         self._legacy_tag = legacy_tag
         """
-        Optional classification legacy_tag applied to this transaction.
+        A short message attached to the transaction.
+
+        .. warning::
+            Deprecated, use :py:attr:`Transaction.tag` instead.
+
+        :type: :py:class:`Tag`
         """
 
         self.nonce = nonce
         """
         Unique value used to increase security of the transaction hash.
+
+        This is the product of the PoW process.
+
+        :type: :py:class:`Nonce`
         """
 
         self.timestamp = timestamp
         """
         Timestamp used to increase the security of the transaction hash.
 
+        Describes when the transaction was created.
+
         .. important::
             This value is easy to forge!
             Do not rely on it when resolving conflicts!
+
+        :type: ``int``, unix timestamp in seconds.
         """
 
         self.current_index = current_index
         """
         The position of the transaction inside the bundle.
 
+           - If the ``current_index`` value is 0, then this is the "head transaction".
+           - If it is equal to ``last_index``, then this is the "tail transaction".
+
         For value transfers, the "spend" transaction is generally in the
         0th position, followed by inputs, and the "change" transaction
         is last.
+
+        :type: ``int``
         """
 
         self.last_index = last_index
         """
-        The position of the final transaction inside the bundle.
+        The index of the final transaction in the bundle.
+
+        This value is attached to every transaction to make it easier to
+        traverse and verify bundles.
+
+        :type: ``int``
         """
 
         self.trunk_transaction_hash = trunk_transaction_hash
         """
+        The transaction hash of the next transaction in the bundle.
+
         In order to add a transaction to the Tangle, the client must
         perform PoW to "approve" two existing transactions, called the
         "trunk" and "branch" transactions.
 
         The trunk transaction is generally used to link transactions
         within a bundle.
+
+        :type: :py:class:`TransactionHash`
         """
 
         self.branch_transaction_hash = branch_transaction_hash
         """
+        An unrelated transaction that this transaction "approves".
+
         In order to add a transaction to the Tangle, the client must
         perform PoW to "approve" two existing transactions, called the
         "trunk" and "branch" transactions.
@@ -174,18 +329,41 @@ class Transaction(JsonSerializable):
         The branch transaction may be selected strategically to maximize
         the bundle's chances of getting confirmed; otherwise it usually
         has no significance.
+
+        :type: :py:class:`TransactionHash`
         """
 
         self.tag = tag
         """
         Optional classification tag applied to this transaction.
+
+        Many transactions have empty tags (``Tag(b'999999999999999999999999999')``).
+
+        :type: :py:class:`Tag`
         """
 
         self.attachment_timestamp = attachment_timestamp
+        """
+        Estimated epoch time of the attachment to the tangle.
+
+        Decribes when the proof-of-work for this transaction was done.
+
+        :type: ``int``, unix timestamp in milliseconds,
+        """
 
         self.attachment_timestamp_lower_bound = attachment_timestamp_lower_bound
+        """
+        The lowest possible epoch time of the attachment to the tangle.
+
+        :type: ``int``, unix timestamp in milliseconds.
+        """
 
         self.attachment_timestamp_upper_bound = attachment_timestamp_upper_bound
+        """
+        The highest possible epoch time of the attachment to the tangle.
+
+        :type: ``int``, unix timestamp in milliseconds.
+        """
 
         self.signature_message_fragment = signature_message_fragment
         """
@@ -203,6 +381,8 @@ class Transaction(JsonSerializable):
           pretty much any value.  Like signatures, the message may be
           split across multiple transactions if it is too large to fit
           inside a single transaction.
+
+        :type: :py:class:`Fragment`
         """
 
         self.is_confirmed = None  # type: Optional[bool]
@@ -210,10 +390,12 @@ class Transaction(JsonSerializable):
         Whether this transaction has been confirmed by neighbor nodes.
         Must be set manually via the ``getInclusionStates`` API command.
 
+        :type: ``Optional[bool]``
+
         References:
 
-        - :py:meth:`iota.api.StrictIota.get_inclusion_states`
-        - :py:meth:`iota.api.Iota.get_transfers`
+        - :py:meth:`Iota.get_inclusion_states`
+        - :py:meth:`Iota.get_transfers`
         """
 
     @property
@@ -312,6 +494,28 @@ class Transaction(JsonSerializable):
         """
         Returns a JSON-compatible representation of the object.
 
+        :return:
+            ``dict`` with the following structure::
+
+                {
+                    'hash_': TransactionHash,
+                    'signature_message_fragment': Fragment,
+                    'address': Address,
+                    'value': int,
+                    'legacy_tag': Tag,
+                    'timestamp': int,
+                    'current_index': int,
+                    'last_index': int,
+                    'bundle_hash': BundleHash,
+                    'trunk_transaction_hash': TransactionHash,
+                    'branch_transaction_hash': TransactionHash,
+                    'tag': Tag,
+                    'attachment_timestamp': int,
+                    'attachment_timestamp_lower_bound': int,
+                    'attachment_timestamp_upper_bound': int,
+                    'nonce': Nonce,
+                }
+
         References:
 
         - :py:class:`iota.json.JsonEncoder`.
@@ -344,6 +548,9 @@ class Transaction(JsonSerializable):
         # type: () -> TransactionTrytes
         """
         Returns a TryteString representation of the transaction.
+
+        :return:
+            :py:class:`TryteString` object.
         """
         return TransactionTrytes(
             self.signature_message_fragment
@@ -368,6 +575,9 @@ class Transaction(JsonSerializable):
         """
         Returns the values needed to validate the transaction's
         ``signature_message_fragment`` value.
+
+        :return:
+            :py:class:`TryteString` object.
         """
         return (
                 self.address.address
@@ -399,9 +609,16 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
     Instead, Bundles must be inferred by following linked transactions
     with the same bundle hash.
 
+    :param Optional[Iterable[Transaction]] transactions:
+        Transactions in the bundle. Note that transactions will be sorted into
+        ascending order based on their ``current_index``.
+
+    :return:
+        :py:class:`Bundle` object.
+
     References:
 
-    - :py:class:`iota.commands.extended.get_bundles.GetBundlesCommand`
+    - :py:class:`Iota.get_transfers`
     """
 
     @classmethod
@@ -409,6 +626,26 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
         # type: (Iterable[TryteString]) -> Bundle
         """
         Creates a Bundle object from a list of tryte values.
+
+        Note, that this is effectively calling
+        :py:meth:`Transaction.from_tryte_string` on the iterbale elements and
+        constructing the bundle from the created transactions.
+
+        :param Iterable[TryteString] trytes:
+            List of raw transaction trytes.
+
+        :return:
+            :py:class:`Bundle` object.
+
+        Example usage::
+
+            from iota import Bundle
+            bundle = Bundle.from_tryte_strings([
+                b'GYPRVHBEZOOFXSHQBLCYW9ICTCISLHDBNMMVYD9JJHQMPQCTIQAQTJNNNJ9IDXLRCC...',
+                b'OYOXYPCLR9PBEY9ORZIEPPDNTI9CQWYZUOTAVBXPSBOFEQAPFLWXSWUIUSJMSJIIIZ...',
+                # etc.
+            ])
+
         """
         return cls(map(Transaction.from_tryte_string, trytes))
 
@@ -417,6 +654,9 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
         super(Bundle, self).__init__()
 
         self.transactions = []  # type: List[Transaction]
+        """
+        List of :py:class:`Transaction` objects that are in the bundle.
+        """
         if transactions:
             self.transactions.extend(
                 sorted(transactions, key=attrgetter('current_index')),
@@ -429,7 +669,7 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
 
         References:
 
-        - :py:class:`iota.commands.extended.get_transfers.GetTransfersCommand`
+        - :py:class:`Iota.get_transfers`
         """
 
     def __contains__(self, transaction):
@@ -457,9 +697,11 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
 
         This attribute must be set manually.
 
+        :return: ``bool``
+
         References:
 
-        - :py:class:`iota.commands.extended.get_transfers.GetTransfersCommand`
+        - :py:class:`Iota.get_transfers`
         """
         return self._is_confirmed
 
@@ -483,7 +725,9 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
         This value is determined by inspecting the bundle's tail
         transaction, so in a few edge cases, it may be incorrect.
 
-        If the bundle has no transactions, this method returns ``None``.
+        :return:
+            - :py:class:`BundleHash` object, or
+            - If the bundle has no transactions, this method returns ``None``.
         """
         try:
             return self.tail_transaction.bundle_hash
@@ -495,6 +739,8 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
         # type: () -> Transaction
         """
         Returns the tail transaction of the bundle.
+
+        :return: :py:class:`Transaction`
         """
         return self[0]
 
@@ -504,7 +750,7 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
         Attempts to decipher encoded messages from the transactions in
         the bundle.
 
-        :param errors:
+        :param Text errors:
             How to handle trytes that can't be converted, or bytes that
             can't be decoded using UTF-8:
 
@@ -519,6 +765,8 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
 
             'ignore'
                 Omit the invalid tryte/byte sequence.
+
+        :return: ``List[Text]``
         """
         decode_errors = 'strict' if errors == 'drop' else errors
 
@@ -548,7 +796,7 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
         Returns TryteString representations of the transactions in this
         bundle.
 
-        :param head_to_tail:
+        :param bool head_to_tail:
             Determines the order of the transactions:
 
             - ``True``: head txn first, tail txn last.
@@ -556,6 +804,8 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
 
             Note that the order is reversed by default, as this is the
             way bundles are typically broadcast to the Tangle.
+
+        :return: ``List[TransactionTrytes]``
         """
         transactions = self if head_to_tail else reversed(self)
         return [t.as_tryte_string() for t in transactions]
@@ -564,6 +814,10 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
         # type: () -> List[dict]
         """
         Returns a JSON-compatible representation of the object.
+
+        :return:
+            ``List[dict]``. The ``dict`` list elements contain individual
+            transactions as in :py:meth:`Transaction.as_json_compatible`.
 
         References:
 
@@ -575,6 +829,9 @@ class Bundle(JsonSerializable, Sequence[Transaction]):
         # type: () -> List[List[Transaction]]
         """
         Groups transactions in the bundle by address.
+
+        :return:
+            ``List[List[Transaction]]``
         """
         groups = []
 

--- a/iota/transaction/types.py
+++ b/iota/transaction/types.py
@@ -17,21 +17,24 @@ __all__ = [
 
 class BundleHash(Hash):
     """
-    A TryteString that acts as a bundle hash.
+    An :py:class:`TryteString` (:py:class:`Hash`) that acts as a bundle hash.
     """
     pass
 
 
 class TransactionHash(Hash):
     """
-    A TryteString that acts as a transaction hash.
+    An :py:class:`TryteString` (:py:class:`Hash`) that acts as a transaction hash.
     """
     pass
 
 
 class Fragment(TryteString):
     """
-    A signature/message fragment in a transaction.
+    An :py:class:`TryteString` representation of a signature/message fragment
+    in a transaction.
+
+    :raises ValueError: if ``trytes`` is longer than 2187 trytes in length.
     """
     LEN = FRAGMENT_LENGTH
     """
@@ -57,7 +60,9 @@ class Fragment(TryteString):
 
 class TransactionTrytes(TryteString):
     """
-    A TryteString representation of a Transaction.
+    An :py:class:`TryteString` representation of a Transaction.
+
+    :raises ValueError: if ``trytes`` is longer than 2673 trytes in length.
     """
     LEN = 2673
     """
@@ -83,7 +88,9 @@ class TransactionTrytes(TryteString):
 
 class Nonce(TryteString):
     """
-    A TryteString that acts as a transaction nonce.
+    An :py:class:`TryteString` that acts as a transaction nonce.
+
+    :raises ValueError: if ``trytes`` is longer than 27 trytes in length.
     """
     LEN = 27
     """


### PR DESCRIPTION

## Related issue #268 

## Changes
 - Complete rewerite of `types.rst`
 - Add/extend/polish docstrings for several type classes
 - Small correction in `basic_concepts.rst`

`PyOTA types` in its current form presents the data types that a regular user of the library is interested in to generate seeds, addresses, transactions, bundles, etc.

It might be beneficial to include an additional page in the future `Advanced PyOTA Data Types` that is  intended towards people who do development on the lib. Right now the entry barrier to development seems to be quite high due to lack of proper introduction and in-depth documentation. 