### PR TITLE
Add `wereAddressesSpentFrom` check to used/new address discovery

### DIFF
--- a/docs/addresses.rst
+++ b/docs/addresses.rst
@@ -17,16 +17,10 @@ any other financial service.
         These performance issues will be fixed in a future version of the library;
         please bear with us!
 
-        In the meantime, if you are using Python 3, you can install a C extension
+        In the meantime, you can install a C extension
         that boosts PyOTA's performance significantly (speedups of 60x are common!).
 
         To install the extension, run ``pip install pyota[ccurl]``.
-
-        **Important:** The extension is not yet compatible with Python 2.
-
-        If you are familiar with Python 2's C API, we'd love to hear from you!
-        Check the `GitHub issue <https://github.com/todofixthis/pyota-ccurl/issues/4>`_
-        for more information.
 
 PyOTA provides two methods for generating addresses:
 
@@ -60,7 +54,9 @@ method, using the following parameters:
    (defaults to 1).
 -  If ``None``, the API will generate addresses until it finds one that
    has not been used (has no transactions associated with it on the
-   Tangle). It will then return the unused address and discard the rest.
+   Tangle, and was not spent from). This makes the command safer to use after
+   a snapshot has been taken. It will then return the unused address and
+   discard the rest.
 -  ``security_level: int``: Determines the security level of the
    generated addresses. See `Security Levels <#security-levels>`__
    below.

--- a/iota/api.py
+++ b/iota/api.py
@@ -1217,8 +1217,9 @@ class Iota(StrictIota):
                 inside a loop.
 
             If ``None``, this method will progressively generate
-            addresses and scan the Tangle until it finds one that has no
-            transactions referencing it.
+            addresses and scan the Tangle until it finds one that is unused.
+            This is if no transactions are referencing it and it was not spent
+            from before.
 
         :param int security_level:
             Number of iterations to use when generating new addresses.

--- a/iota/commands/extended/get_account_data.py
+++ b/iota/commands/extended/get_account_data.py
@@ -59,7 +59,7 @@ class GetAccountDataCommand(FilterCommand):
             my_hashes = ft_command(addresses=my_addresses).get('hashes') or []
 
         account_balance = 0
-        if my_hashes:
+        if my_addresses:
             # Load balances for the addresses that we generated.
             gb_response = (
                 GetBalancesCommand(self.adapter)(addresses=my_addresses)

--- a/test/commands/extended/get_account_data_test.py
+++ b/test/commands/extended/get_account_data_test.py
@@ -435,3 +435,28 @@ class GetAccountDataCommandTestCase(TestCase):
         'bundles':    [],
       },
     )
+
+  def test_balance_is_found_for_address_without_transaction(self):
+    """
+    If an address has a balance, no transactions and was spent from, the
+    balance should still be found and returned.
+    """
+    with mock.patch(
+        'iota.commands.extended.get_account_data.iter_used_addresses',
+        mock.Mock(return_value=[(self.addy1, [])]),
+    ):
+      self.adapter.seed_response('getBalances', {
+        'balances': [42],
+      })
+
+      response = self.command(seed=Seed.random())
+
+    self.assertDictEqual(
+      response,
+
+      {
+        'addresses':  [self.addy1],
+        'balance':    42,
+        'bundles':    [],
+      },
+    )

--- a/test/commands/extended/get_inputs_test.py
+++ b/test/commands/extended/get_inputs_test.py
@@ -590,12 +590,9 @@ class GetInputsCommandTestCase(TestCase):
     """
     No ``stop`` provided, balance meets ``threshold``.
     """
-    self.adapter.seed_response('getBalances', {
-      'balances': [42, 29],
-    })
 
-    # ``getInputs`` uses ``findTransactions`` to identify unused
-    # addresses.
+    # ``getInputs`` uses ``findTransactions`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
@@ -618,6 +615,14 @@ class GetInputsCommandTestCase(TestCase):
 
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [42, 29],
     })
 
     # To keep the unit test nice and speedy, we will mock the address
@@ -686,12 +691,9 @@ class GetInputsCommandTestCase(TestCase):
     """
     No ``stop`` provided, ``threshold`` is 0.
     """
-    # Note that the first address has a zero balance.
-    self.adapter.seed_response('getBalances', {
-      'balances': [0, 1],
-    })
 
-    # ``getInputs`` uses ``findTransactions`` to identify unused
+    # ``getInputs`` uses ``findTransactions`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
@@ -715,6 +717,15 @@ class GetInputsCommandTestCase(TestCase):
 
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    # Note that the first address has a zero balance.
+    self.adapter.seed_response('getBalances', {
+      'balances': [0, 1],
     })
 
     # To keep the unit test nice and speedy, we will mock the address
@@ -750,12 +761,9 @@ class GetInputsCommandTestCase(TestCase):
     """
     No ``stop`` provided, no ``threshold``.
     """
-    self.adapter.seed_response('getBalances', {
-      'balances': [42, 29],
-    })
 
-    # ``getInputs`` uses ``findTransactions`` to identify unused
-    # addresses.
+    # ``getInputs`` uses ``findTransactions`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
@@ -778,6 +786,14 @@ class GetInputsCommandTestCase(TestCase):
 
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [42, 29],
     })
 
     # To keep the unit test nice and speedy, we will mock the address
@@ -818,12 +834,9 @@ class GetInputsCommandTestCase(TestCase):
     """
     Using ``start`` to offset the key range.
     """
-    self.adapter.seed_response('getBalances', {
-      'balances': [86],
-    })
 
-    # ``getInputs`` uses ``findTransactions`` to identify unused
-    # addresses.
+    # ``getInputs`` uses ``findTransactions`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
@@ -836,6 +849,14 @@ class GetInputsCommandTestCase(TestCase):
 
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [86],
     })
 
     # To keep the unit test nice and speedy, we will mock the address
@@ -926,11 +947,8 @@ class GetInputsCommandTestCase(TestCase):
     seed = Seed.random()
     address = AddressGenerator(seed, security_level=1).get_addresses(0)[0]
 
-    self.adapter.seed_response('getBalances', {
-      'balances': [86],
-    })
-    # ``getInputs`` uses ``findTransactions`` to identify unused
-    # addresses.
+    # ``getInputs`` uses ``findTransactions`` and
+    # ``wereAddressesSpentFrom`` to identify unused addresses.
     # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
@@ -942,6 +960,14 @@ class GetInputsCommandTestCase(TestCase):
     })
     self.adapter.seed_response('findTransactions', {
       'hashes': [],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+
+    self.adapter.seed_response('getBalances', {
+      'balances': [86],
     })
 
     response = GetInputsCommand(self.adapter)(

--- a/test/commands/extended/get_new_addresses_test.py
+++ b/test/commands/extended/get_new_addresses_test.py
@@ -423,20 +423,20 @@ class GetNewAddressesCommandTestCase(TestCase):
       },
     )
 
-  def test_get_addresses_online(self):
+  def test_get_addresses_online_already_spent_from(self):
     """
-    Generate address in online mode (filtering used addresses).
+    Generate address in online mode (filtering used addresses). Test if an
+    address that was already spent from will not be returned.
     """
-    # Pretend that ``self.addy1`` has already been used, but not
-    # ``self.addy2``.
-    # noinspection SpellCheckingInspection
-    self.adapter.seed_response('findTransactions', {
-      'duration': 18,
+    # Pretend that ``self.addy1`` has no transactions but already been
+    # spent from, but ``self.addy2`` is not used.
 
-      'hashes': [
-        'TESTVALUE9DONTUSEINPRODUCTION99999ITQLQN'
-        'LPPG9YNAARMKNKYQO9GSCSBIOTGMLJUFLZWSY9999',
-      ],
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [True],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
     })
 
     self.adapter.seed_response('findTransactions', {
@@ -461,14 +461,73 @@ class GetNewAddressesCommandTestCase(TestCase):
     self.assertListEqual(
       self.adapter.requests,
 
-      # The command issued two `findTransactions` API requests: one for
-      # each address generated, until it found an unused address.
+      # The command issued a `wereAddressesSpentFrom` API request to
+      # check if the first address was used. Then it called `wereAddressesSpentFrom`
+      # and `findTransactions` to verify that the second address was
+      # indeed not used.
       [
         {
-          'command':    'findTransactions',
+          'command': 'wereAddressesSpentFrom',
           'addresses':  [self.addy_1],
         },
+        {
+          'command': 'wereAddressesSpentFrom',
+          'addresses':  [self.addy_2],
+        },
+        {
+          'command':    'findTransactions',
+          'addresses':  [self.addy_2],
+        },
+      ],
+    )
 
+  def test_get_addresses_online_has_transaction(self):
+    """
+    Generate address in online mode (filtering used addresses). Test if an
+    address that has a transaction will not be returned.
+    """
+    # Pretend that ``self.addy1`` has a transaction, but
+    # ``self.addy2`` is not used.
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+    # noinspection SpellCheckingInspection
+    self.adapter.seed_response('findTransactions', {
+      'duration': 18,
+      'hashes': [
+        'TESTVALUE9DONTUSEINPRODUCTION99999ITQLQN'
+        'LPPG9YNAARMKNKYQO9GSCSBIOTGMLJUFLZWSY9999',
+      ],
+    })
+
+    self.adapter.seed_response('wereAddressesSpentFrom', {
+      'states': [False],
+    })
+    self.adapter.seed_response('findTransactions', {
+      'hashes':   [],
+    })
+
+    response = self.command(index=0, seed=self.seed)
+
+    # The command determined that ``self.addy1`` was already used, so
+    # it skipped that one.
+    self.assertDictEqual(response, {'addresses': [self.addy_2]})
+
+    self.assertListEqual(
+      self.adapter.requests,
+      [
+        {
+          'command': 'wereAddressesSpentFrom',
+          'addresses':  [self.addy_1],
+        },
+        {
+          'command': 'findTransactions',
+          'addresses': [self.addy_1],
+        },
+        {
+          'command': 'wereAddressesSpentFrom',
+          'addresses':  [self.addy_2],
+        },
         {
           'command':    'findTransactions',
           'addresses':  [self.addy_2],

--- a/test/commands/extended/get_transfers_test.py
+++ b/test/commands/extended/get_transfers_test.py
@@ -372,13 +372,19 @@ class GetTransfersCommandTestCase(TestCase):
       },
     )
 
-    # The second address is unused.
+    # The second address is unused. It has no transactions and was not spent from.
     self.adapter.seed_response(
       'findTransactions',
 
       {
         'duration': 1,
         'hashes':   [],
+      },
+    )
+    self.adapter.seed_response(
+      'wereAddressesSpentFrom',
+      {
+        'states': [False],
       },
     )
 
@@ -461,6 +467,12 @@ class GetTransfersCommandTestCase(TestCase):
         'hashes':   [],
       },
     )
+    self.adapter.seed_response(
+      'wereAddressesSpentFrom',
+      {
+        'states': [False],
+      },
+    )
 
     with mock.patch(
         'iota.crypto.addresses.AddressGenerator.create_iterator',
@@ -495,13 +507,20 @@ class GetTransfersCommandTestCase(TestCase):
       },
     )
 
-    # The second address is unused.
+    # The second address is unused. It has no transactions and was not spent from.
     self.adapter.seed_response(
       'findTransactions',
 
       {
         'duration': 1,
         'hashes':   [],
+      },
+    )
+
+    self.adapter.seed_response(
+      'wereAddressesSpentFrom',
+      {
+        'states': [True],
       },
     )
 

--- a/test/commands/extended/prepare_transfer_test.py
+++ b/test/commands/extended/prepare_transfer_test.py
@@ -1307,10 +1307,14 @@ class PrepareTransferCommandTestCase(TestCase):
     # testing for several security levels
     for security_level in SECURITY_LEVELS_TO_TEST:
 
-      # get_new_addresses uses `find_transactions` internaly.
+      # get_new_addresses uses `find_transactions` and
+      # `were_addresses_spent_from` internally.
       # The following means requested address is considered unused
       self.adapter.seed_response('findTransactions', {
         'hashes': [],
+      })
+      self.adapter.seed_response('wereAddressesSpentFrom', {
+        'states': [False],
       })
 
       self.command.reset()
@@ -1377,8 +1381,8 @@ class PrepareTransferCommandTestCase(TestCase):
     # testing several security levels
     for security_level in SECURITY_LEVELS_TO_TEST:
 
-      # get_inputs use iter_used_addresses and findTransactions.
-      # until address without tx found
+      # get_inputs uses iter_used_addresses, findTransactions,
+      # and wereAddressesSpentFrom until an unused address is found.
       self.adapter.seed_response('findTransactions', {
         'hashes': [
           TransactionHash(
@@ -1390,8 +1394,16 @@ class PrepareTransferCommandTestCase(TestCase):
       self.adapter.seed_response('findTransactions', {
         'hashes': [],
       })
+      self.adapter.seed_response('wereAddressesSpentFrom', {
+        'states': [False],
+      })
 
-      # get_new_addresses uses `find_transactions` internaly.
+      # get_new_addresses uses `find_transactions`, `get_balances` and
+      # `were_addresses_spent_from` internally.
+
+      self.adapter.seed_response('wereAddressesSpentFrom', {
+        'states': [False],
+      })
       self.adapter.seed_response('findTransactions', {
         'hashes': [],
       })


### PR DESCRIPTION
## This PR contains parts of #244

## Details
So far only `findTransactions` check was made in `iter_used_addresses` and `get_new_addresses`.

With these changes, a **used address** becomes:
- an address that has transaction(s) associated with it on the Tangle,
- OR was ever spent from.

A **new address** becomes:
- an address that has no transaction(s) associated with it on the Tangle,
- AND was never spent from.

These changes are needed to achieve identical behavior with the JS lib.

Huge thanks to @pdecol, who did the initial implementation and pull request!