### PR TITLE
docs: improve `Adapters and Wrappers` page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,8 +47,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'PyOTA'
-copyright = '2017, Phoenix Zerin'
-author = 'Phoenix Zerin'
+copyright = '2019, Phoenix Zerin & Levente Pap'
+author = 'Phoenix Zerin, Levente Pap'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/iota/adapter/wrappers.py
+++ b/iota/adapter/wrappers.py
@@ -44,21 +44,53 @@ class BaseWrapper(BaseAdapter):
 
 class RoutingWrapper(BaseWrapper):
     """
-    Routes commands to different nodes.
+    Routes commands (API requests) to different nodes depending on the command
+    name.
 
     This allows you to, for example, send POW requests to a local node,
     while routing all other requests to a remote one.
 
-    Example:
+    Once you've initialized the :py:class:`RoutingWrapper`, invoke its
+    :py:meth:`add_route` method to specify a different adapter to use for a
+    particular command.
+
+    :param AdapterSpec default_adapter:
+        RoutingWrapper must be initialized with a default URI/adapter.
+        This is the adapter that will be used for any command that doesn’t have
+        a route associated with it.
+
+    :return:
+        :py:class:`RoutingWrapper` object.
+
+    Example usage:
 
     .. code-block:: python
 
-        # Route POW to localhost, everything else to 12.34.56.78.
-        iota = Iota(
-          RoutingWrapper('http://12.34.56.78:14265')
+        from iota import Iota
+        from iota.adapter.wrappers import RoutingWrapper
+
+        # Route POW to localhost, everything else to 'https://nodes.thetangle.org:443'.
+        api = Iota(
+          RoutingWrapper('https://nodes.thetangle.org:443.'')
             .add_route('attachToTangle', 'http://localhost:14265')
             .add_route('interruptAttachingToTangle', 'http://localhost:14265')
         )
+
+    .. note::
+
+        A common use case for :py:class:`RoutingWrapper` is to perform
+        proof-of-work on a specific (local) node, but let all other requests go to another node.
+        Take care when you use :py:class:`RoutingWrapper` adapter and ``local_pow``
+        parameter together in an API instance (see :py:class:`iota.Iota`), because the behavior might not
+        be obvious.
+
+        ``local_pow`` tells the API to perform proof-of-work (:py:meth:`iota.Iota.attach_to_tangle`)
+        without relying on an actual node. It does this by calling an extension
+        package `PyOTA-PoW <https://pypi.org/project/PyOTA-PoW/>`_ that does the
+        job. In PyOTA, this means the request doesn't reach the adapter, it
+        is redirected before.
+        As a consequence,  ``local_pow`` has precedence over the route that is
+        defined in :py:class:`RoutingWrapper`.
     """
 
     def __init__(self, default_adapter):
@@ -80,11 +112,18 @@ class RoutingWrapper(BaseWrapper):
         """
         Adds a route to the wrapper.
 
-        :param command:
-            The name of the command to route (e.g., "attachToTangle").
+        :param Text command:
+            The name of the command. Note that this is the camelCase version of
+            the command name (e.g., ``attachToTangle``, not ``attach_to_tangle``).
 
-        :param adapter:
+        :param AdapterSpec adapter:
             The adapter object or URI to route requests to.
+
+        :return:
+            The :py:class:`RoutingWrapper` object it was called on. Useful for
+            chaining the operation of adding routes in code.
+
+        See :py:class:`RoutingWrapper` for example usage.
         """
         if not isinstance(adapter, BaseAdapter):
             try:


### PR DESCRIPTION
## Related issue #268 

## Changes
- Add more documentation on `HttpAdapter` and `MockAdapter`.
- Add examples on debugging http requests, saving to file or printing to console with/without special formatters.
- Remove `SandboxAdapter` section from documentation, as the class itself will be deprecated in the future, see #273.
- Restructure `RoutingWrapper` for autodoc and improvements.