### PR TITLE
fix: traverse_bundle checks for zero trytes

### DIFF
--- a/iota/commands/extended/traverse_bundle.py
+++ b/iota/commands/extended/traverse_bundle.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 import filters as f
 
 from iota import BadApiResponse, BundleHash, Transaction, \
-    TransactionHash, TryteString, Bundle
+    TransactionHash, TryteString, Bundle, TransactionTrytes
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core.get_trytes import GetTrytesCommand
 from iota.exceptions import with_context
@@ -55,10 +55,13 @@ class TraverseBundleCommand(FilterCommand):
             GetTrytesCommand(self.adapter)(hashes=[txn_hash])['trytes']
         )  # type: List[TryteString]
 
-        if not trytes:
+        # If no tx was found by the node for txn_hash, it returns 9s,
+        # so we check here if it returned all 9s trytes.
+        if not trytes or trytes == [TransactionTrytes('')]:
             raise with_context(
                 exc=BadApiResponse(
-                    'Bundle transactions not visible '
+                    'Could not get trytes of bundle transaction from the Tangle. '
+                    'Bundle transactions not visible.'
                     '(``exc.context`` has more info).',
                 ),
 

--- a/test/commands/extended/traverse_bundle_test.py
+++ b/test/commands/extended/traverse_bundle_test.py
@@ -451,3 +451,20 @@ class TraverseBundleCommandTestCase(TestCase):
                         b'ORYCRDX9TOMJPFCRB9R9KPUUGFPVOWYXFIWEW9999'
                     ),
             )
+
+    def test_missing_transaction_zero_trytes(self):
+        """
+        Unable to find the requested transaction.
+        getTrytes returned only zeros, no tx was found.
+        """
+        zero_trytes = TransactionTrytes('')
+        self.adapter.seed_response('getTrytes', {'trytes': [zero_trytes]})
+
+        with self.assertRaises(BadApiResponse):
+            self.command(
+                transaction =
+                    TransactionHash(
+                        b'FSEWUNJOEGNUI9QOCRFMYSIFAZLJHKZBPQZZYFG9'
+                        b'ORYCRDX9TOMJPFCRB9R9KPUUGFPVOWYXFIWEW9999'
+                    ),
+            )


### PR DESCRIPTION
## Solves: #291
## Description
`get_bundles` calls `traverseBundleCommand` internally, which in turn calls `getTrytesCommand` to fetch the trytes for transactions in the bundle.

> If a node doesn't have the trytes for a given transaction hash in its ledger, the value at the index of that transaction hash is either null or a string of 9s.

Therefore, `getTrytesCommand`  doesn't return an empty list, rather a list with an empty transaction in it, meaning that all trytes of the transaction are '9's.

Detecting such cases when trying to fetch a bundle from the Tangle and throwing an exception.