### PR TITLE
`get_bundles` can return multiple bundles

### DIFF
--- a/iota/api.py
+++ b/iota/api.py
@@ -983,14 +983,14 @@ class Iota(StrictIota):
             security_level=security_level
         )
 
-    def get_bundles(self, transaction):
-        # type: (TransactionHash) -> dict
+    def get_bundles(self, transactions):
+        # type: (Iterable[TransactionHash]) -> dict
         """
         Returns the bundle(s) associated with the specified transaction
-        hash.
+        hashes.
 
-        :param TransactionHash transaction:
-            Transaction hash.  Must be a tail transaction.
+        :param Iterable[TransactionHash] transactions:
+            Transaction hashes.  Must be a tail transaction.
 
         :return:
             ``dict`` with the following structure::
@@ -1001,15 +1001,15 @@ class Iota(StrictIota):
                     always a list, even if only one bundle was found.
              }
 
-        :raise:
-          - :py:class:`iota.adapter.BadApiResponse` if any of the
-            bundles fails validation.
+        :raise :py:class:`iota.adapter.BadApiResponse`:
+          - if any of the bundles fails validation.
+          - if any of the bundles is not visible on the Tangle.
 
         References:
 
         - https://github.com/iotaledger/wiki/blob/master/api-proposal.md#getbundle
         """
-        return extended.GetBundlesCommand(self.adapter)(transaction=transaction)
+        return extended.GetBundlesCommand(self.adapter)(transactions=transactions)
 
     def get_inputs(
             self,

--- a/iota/commands/extended/broadcast_bundle.py
+++ b/iota/commands/extended/broadcast_bundle.py
@@ -36,7 +36,7 @@ class BroadcastBundleCommand(FilterCommand):
         # and validates it.
         # Returns List[List[TransactionTrytes]]
         # (outer list has one item in current implementation)
-        bundle = GetBundlesCommand(self.adapter)(transaction=request['tail_hash'])
+        bundle = GetBundlesCommand(self.adapter)(transactions=[request['tail_hash']])
         BroadcastTransactionsCommand(self.adapter)(trytes=bundle[0])
         return {
             'trytes': bundle[0],

--- a/iota/commands/extended/replay_bundle.py
+++ b/iota/commands/extended/replay_bundle.py
@@ -34,7 +34,7 @@ class ReplayBundleCommand(FilterCommand):
         min_weight_magnitude = request['minWeightMagnitude']  # type: int
         transaction = request['transaction']  # type: TransactionHash
 
-        gb_response = GetBundlesCommand(self.adapter)(transaction=transaction)
+        gb_response = GetBundlesCommand(self.adapter)(transactions=[transaction])
 
         # Note that we only replay the first bundle returned by
         # ``getBundles``.

--- a/iota/commands/extended/utils.py
+++ b/iota/commands/extended/utils.py
@@ -118,7 +118,7 @@ def get_bundles_from_transaction_hashes(
 
     # Find the bundles for each transaction.
     for txn in tail_transactions:
-        gb_response = GetBundlesCommand(adapter)(transaction=txn.hash)
+        gb_response = GetBundlesCommand(adapter)(transactions=[txn.hash])
         txn_bundles = gb_response['bundles']  # type: List[Bundle]
 
         if inclusion_states:


### PR DESCRIPTION
## Solves: #250 

## Changes
- `get_bundles` extended API call accepts a list of tail transaction hashes instead of just one.
- `get_bundles` returns multiple bundles in the same order as the input tail hashes.
- Added test coverage for returning multiple bundles.
- Modified calls to `GetBundlesCommand()` throughout the lib.

WARNING: Breaking change!