### PR TITLE
Fix error message in `PromoteTransactionCommand`

### DIFF
--- a/iota/commands/extended/promote_transaction.py
+++ b/iota/commands/extended/promote_transaction.py
@@ -39,7 +39,7 @@ class PromoteTransactionCommand(FilterCommand):
         if cc_response['state'] is False:
             raise BadApiResponse(
                 'Transaction {transaction} is not promotable. '
-                'You should reattach first.'.format(transaction=transaction)
+                'Info: {reason}'.format(transaction=transaction, reason=cc_response['info'])
             )
 
         spam_transfer = ProposedTransaction(

--- a/test/commands/extended/promote_transaction_test.py
+++ b/test/commands/extended/promote_transaction_test.py
@@ -401,6 +401,7 @@ class PromoteTransactionCommandTestCase(TestCase):
 
     self.adapter.seed_response('checkConsistency', {
       'state': False,
+      'info': 'Something went terribly wrong.',
     })
 
     with self.assertRaises(BadApiResponse):


### PR DESCRIPTION
## Fixes: #311 
## Description
Include the reason from the `info` field of the `CheckConsistencyCommand` response.

This can be for example that the transaction is below max depth, the bundle is invlaid, or the transaction is not solid. This last one happens when one tries to immediately promote a transaction after it has just been broadcast and stored.

IRI Reference:
https://github.com/iotaledger/iri/blob/eb4e1a4409bbf74cc0198c5f2bd1a05524f81f4f/src/main/java/com/iota/iri/service/API.java#L388-L408
