### PR TITLE
PY2 Compatibility Code Cleanup

### DIFF
--- a/examples/address_generator.py
+++ b/examples/address_generator.py
@@ -1,17 +1,11 @@
-# coding=utf-8
 """
 Generates a shiny new IOTA address that you can use for transfers!
 """
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 from argparse import ArgumentParser
 from getpass import getpass as secure_input
 from sys import argv
 from typing import Optional, Text
-
-from six import binary_type, moves as compat, text_type
 
 from iota import Iota, __version__
 from iota.crypto.addresses import AddressGenerator
@@ -38,13 +32,13 @@ def main(uri, index, count, security, checksum):
     # Here's where all the magic happens!
     api_response = api.get_new_addresses(index, count, security, checksum)
     for addy in api_response['addresses']:
-        print(binary_type(addy).decode('ascii'))
+        print(bytes(addy).decode('ascii'))
 
     print('')
 
 
 def get_seed():
-    # type: () -> binary_type
+    # type: () -> bytes
     """
     Prompts the user securely for their seed.
     """
@@ -66,10 +60,10 @@ def output_seed(seed):
         'WARNING: Anyone who has your seed can spend your IOTAs! '
         'Clear the screen after recording your seed!'
     )
-    compat.input('')
+    input('')
     print('Your seed is:')
     print('')
-    print(binary_type(seed).decode('ascii'))
+    print(bytes(seed).decode('ascii'))
     print('')
 
     print(
@@ -77,7 +71,7 @@ def output_seed(seed):
         'and press return to continue.'
     )
     print('https://en.wikipedia.org/wiki/Shoulder_surfing_(computer_security)')
-    compat.input('')
+    input('')
 
 
 if __name__ == '__main__':
@@ -88,7 +82,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--uri',
-        type=text_type,
+        type=str,
         default='http://localhost:14265/',
 
         help=(

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -1,18 +1,13 @@
-# coding=utf-8
 """
 Simple "Hello, world!" example that sends a `getNodeInfo` command to
 your friendly neighborhood node.
 """
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 from argparse import ArgumentParser
 from pprint import pprint
 from sys import argv
 from typing import Text
 from httpx.exceptions import NetworkError
-from six import text_type
 
 from iota import BadApiResponse, StrictIota, __version__
 
@@ -44,7 +39,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--uri',
-        type=text_type,
+        type=str,
         default='http://localhost:14265/',
 
         help=(

--- a/examples/local_pow.py
+++ b/examples/local_pow.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import iota
 from pprint import pprint
 

--- a/examples/mam_js_send.py
+++ b/examples/mam_js_send.py
@@ -1,6 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 import codecs
 import json
@@ -10,7 +7,6 @@ from subprocess import PIPE, run
 from typing import List, Optional, Text
 
 import filters as f
-from six import binary_type, text_type
 
 from iota import Bundle, Iota, TransactionTrytes
 from iota.bin import IotaCommandLineApp
@@ -71,14 +67,14 @@ class IotaMamExample(IotaCommandLineApp):
                 mam_encrypt_path,
 
                 # Required arguments
-                binary_type(api.seed),
+                bytes(api.seed),
                 message,
 
                 # Options
-                '--channel-key-index', text_type(channel_key_index),
-                '--start', text_type(start),
-                '--count', text_type(count),
-                '--security-level', text_type(security_level),
+                '--channel-key-index', str(channel_key_index),
+                '--start', str(start),
+                '--count', str(count),
+                '--security-level', str(security_level),
             ],
 
             check=True,

--- a/examples/multisig.py
+++ b/examples/multisig.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """
 Example of how to use PyOTA's multisig feature.
 
@@ -9,9 +8,6 @@ finally broadcast the transactions to the Tangle.
 References:
   - https://github.com/iotaledger/wiki/blob/master/multisigs.md
 """
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 from typing import List
 
@@ -35,7 +31,6 @@ participants don't have to share their seeds.
 ##
 # Create digest 1 of 3.
 #
-# noinspection SpellCheckingInspection
 api_1 = MultisigIota(
     adapter='http://localhost:14265',
 
@@ -64,7 +59,6 @@ digest_1 = gd_result['digests'][0]  # type: Digest
 ##
 # Create digest 2 of 3.
 #
-# noinspection SpellCheckingInspection
 api_2 = MultisigIota(
     adapter='http://localhost:14265',
 
@@ -83,7 +77,6 @@ digest_2 = gd_result['digests'][0]  # type: Digest
 ##
 # Create digest 3 of 3.
 #
-# noinspection SpellCheckingInspection
 api_3 = MultisigIota(
     adapter='http://localhost:14265',
 
@@ -128,7 +121,6 @@ multisig address, or generate a new multisig address that will receive
 the change from the transaction!
 """
 
-# noinspection SpellCheckingInspection
 pmt_result = api_1.prepare_multisig_transfer(
     # These are the transactions that will spend the IOTAs.
     # You can divide up the IOTAs to send to multiple addresses if you

--- a/examples/routingwrapper_pow.py
+++ b/examples/routingwrapper_pow.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """
 Simple example using the RoutingWrapper to route API requests to
 different nodes.
@@ -18,7 +17,6 @@ router.add_route('attachToTangle', 'http://localhost:14265')
 api = Iota(router, seed=b'SEED9GOES9HERE')
 
 # Example of sending a transfer using the adapter.
-# noinspection SpellCheckingInspection
 bundle = api.send_transfer(
     depth=3,
 

--- a/examples/send_transfer.py
+++ b/examples/send_transfer.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """
 Example script that shows how to use PyOTA to send a transfer to an address.
 """
@@ -13,7 +12,6 @@ from iota import (
   Tag,
   TryteString,
 )
-from six import text_type
 from address_generator import get_seed, output_seed
 
 
@@ -60,7 +58,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--address',
-        type=text_type,
+        type=str,
         default=b'RECEIVINGWALLETADDRESSGOESHERE9WITHCHECKSUMANDSECURITYLEVELB999999999999999999999999999999',
         help=
         'Receiving address'
@@ -78,7 +76,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--message',
-        type=text_type,
+        type=str,
         default='Hello World!',
         help=
         'Transfer message.'
@@ -87,7 +85,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--tag',
-        type=text_type,
+        type=str,
         default=b'EXAMPLE',
         help=
         'Transfer tag'
@@ -96,7 +94,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--uri',
-        type=text_type,
+        type=str,
         default='http://localhost:14265/',
         help=
         'URI of the node to connect to.'

--- a/iota/__init__.py
+++ b/iota/__init__.py
@@ -1,6 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 # Define a few magic constants.
 DEFAULT_PORT = 14265

--- a/iota/adapter/wrappers.py
+++ b/iota/adapter/wrappers.py
@@ -1,11 +1,5 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from abc import ABCMeta, abstractmethod as abstract_method
 from typing import Dict, Text
-
-from six import add_metaclass
 
 from iota.adapter import AdapterSpec, BaseAdapter, resolve_adapter
 
@@ -14,8 +8,7 @@ __all__ = [
 ]
 
 
-@add_metaclass(ABCMeta)
-class BaseWrapper(BaseAdapter):
+class BaseWrapper(BaseAdapter, metaclass=ABCMeta):
     """
     Base functionality for "adapter wrappers", used to extend the
     functionality of IOTA adapters.

--- a/iota/bin/__init__.py
+++ b/iota/bin/__init__.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import sys
 from abc import ABCMeta, abstractmethod as abstract_method
 from argparse import ArgumentParser
@@ -9,8 +5,6 @@ from getpass import getpass as secure_input
 from io import StringIO
 from sys import exit
 from typing import Any, Optional, Text
-
-from six import text_type, add_metaclass
 
 from iota import Iota, __version__
 from iota.crypto.types import Seed
@@ -20,8 +14,7 @@ __all__ = [
 ]
 
 
-@add_metaclass(ABCMeta)
-class IotaCommandLineApp(object):
+class IotaCommandLineApp(object, metaclass=ABCMeta):
     """
     Base functionality for a PyOTA-powered command-line application.
     """
@@ -120,7 +113,7 @@ class IotaCommandLineApp(object):
 
         parser.add_argument(
             '--uri',
-            type=text_type,
+            type=str,
             default='http://localhost:14265/',
 
             help=(
@@ -132,7 +125,7 @@ class IotaCommandLineApp(object):
         if self.requires_seed:
             parser.add_argument(
                 '--seed-file',
-                type=text_type,
+                type=str,
                 dest='seed_file',
 
                 help=(
@@ -173,7 +166,7 @@ class IotaCommandLineApp(object):
             'If no seed is specified, a random one will be used instead.\n'
         )
 
-        if isinstance(seed, text_type):
+        if isinstance(seed, str):
             seed = seed.encode('ascii')
 
         return Seed(seed) if seed else Seed.random()

--- a/iota/bin/repl.py
+++ b/iota/bin/repl.py
@@ -1,17 +1,10 @@
 #!/usr/bin/env python
-# coding=utf-8
 """
 Launches a Python shell with a configured API client ready to go.
 """
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from argparse import ArgumentParser
 from logging import basicConfig, getLogger, DEBUG
 from sys import stderr
-
-from six import text_type
-from six.moves import http_client
 
 # Import all IOTA symbols into module scope, so that it's more
 # convenient for the user.
@@ -43,15 +36,13 @@ class IotaReplCommandLineApp(IotaCommandLineApp):
         # If ``debug_requests`` is specified, log HTTP requests/responses.
         if debug_requests:
             # Inject a logger into the IOTA HTTP adapter.
+            # This will turn on logging for underlying httpx client as well
             basicConfig(level=DEBUG, stream=stderr)
 
             logger = getLogger(__name__)
             logger.setLevel(DEBUG)
 
             api.adapter.set_logger(logger)
-
-            # Turn on debugging for the underlying HTTP library.
-            http_client.HTTPConnection.debuglevel = 1
 
         try:
             self._start_repl(api)
@@ -66,7 +57,7 @@ class IotaReplCommandLineApp(IotaCommandLineApp):
 
         parser.add_argument(
             '--pow-uri',
-            type=text_type,
+            type=str,
             default=None,
             dest='pow_uri',
             help='URI of node to send POW requests to.'
@@ -100,7 +91,6 @@ class IotaReplCommandLineApp(IotaCommandLineApp):
         scope_vars = {'api': api}
 
         try:
-            # noinspection PyUnresolvedReferences
             import IPython
         except ImportError:
             # IPython not available; use regular Python REPL.

--- a/iota/codecs.py
+++ b/iota/codecs.py
@@ -1,11 +1,5 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from codecs import Codec, CodecInfo, register as lookup_function
 from warnings import warn
-
-from six import PY3, binary_type
 
 from iota.exceptions import with_context
 
@@ -46,7 +40,6 @@ class AsciiTrytesCodec(Codec):
 
     # :bc: Without the bytearray cast, Python 2 will populate the dict
     # with characters instead of integers.
-    # noinspection SpellCheckingInspection
     alphabet = dict(enumerate(bytearray(b'9ABCDEFGHIJKLMNOPQRSTUVWXYZ')))
     """
     Used to encode bytes into trytes.
@@ -71,13 +64,11 @@ class AsciiTrytesCodec(Codec):
         }
 
         # In Python 2, all codecs are made equal.
-        # In Python 3, some codecs are more equal than others.
-        if PY3:
-            codec_info['_is_text_encoding'] = False
+        # In Python 3, some codecs are more equal than others
+        codec_info['_is_text_encoding'] = False
 
         return CodecInfo(**codec_info)
 
-    # noinspection PyShadowingBuiltins
     def encode(self, input, errors='strict'):
         """
         Encodes a byte string into trytes.
@@ -85,7 +76,7 @@ class AsciiTrytesCodec(Codec):
         if isinstance(input, memoryview):
             input = input.tobytes()
 
-        if not isinstance(input, (binary_type, bytearray)):
+        if not isinstance(input, (bytes, bytearray)):
             raise with_context(
                 exc=TypeError(
                     "Can't encode {type}; byte string expected.".format(
@@ -110,9 +101,8 @@ class AsciiTrytesCodec(Codec):
             trytes.append(self.alphabet[first])
             trytes.append(self.alphabet[second])
 
-        return binary_type(trytes), len(input)
+        return bytes(trytes), len(input)
 
-    # noinspection PyShadowingBuiltins
     def decode(self, input, errors='strict'):
         """
         Decodes a tryte string into bytes.
@@ -120,7 +110,7 @@ class AsciiTrytesCodec(Codec):
         if isinstance(input, memoryview):
             input = input.tobytes()
 
-        if not isinstance(input, (binary_type, bytearray)):
+        if not isinstance(input, (bytes, bytearray)):
             raise with_context(
                 exc=TypeError(
                     "Can't decode {type}; byte string expected.".format(
@@ -190,7 +180,7 @@ class AsciiTrytesCodec(Codec):
                 elif errors == 'replace':
                     bytes_ += b'?'
 
-        return binary_type(bytes_), len(input)
+        return bytes(bytes_), len(input)
 
 
 @lookup_function

--- a/iota/commands/__init__.py
+++ b/iota/commands/__init__.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from abc import ABCMeta, abstractmethod as abstract_method
 from importlib import import_module
 from inspect import getmembers as get_members, isabstract as is_abstract, \
@@ -11,7 +7,6 @@ from types import ModuleType
 from typing import Any, Dict, Mapping, Optional, Text, Union
 
 import filters as f
-import six
 
 from iota.adapter import BaseAdapter
 from iota.exceptions import with_context
@@ -24,8 +19,8 @@ __all__ = [
   'ResponseFilter',
 ]
 
-@six.add_metaclass(ABCMeta)
-class BaseCommand(object):
+
+class BaseCommand(object, metaclass=ABCMeta):
   """
   An API command ready to send to the node.
   """
@@ -197,8 +192,7 @@ class ResponseFilter(f.FilterChain):
     return self._apply({})
 
 
-@six.add_metaclass(ABCMeta)
-class FilterCommand(BaseCommand):
+class FilterCommand(BaseCommand, metaclass=ABCMeta):
   """
   Uses filters to manipulate request/response values.
   """

--- a/iota/commands/core/__init__.py
+++ b/iota/commands/core/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """
 Core commands are defined by the node API.
 
@@ -6,9 +5,6 @@ References:
 
 - https://docs.iota.org/docs/node-software/0.1/iri/references/api-reference
 """
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 from .add_neighbors import *
 from .attach_to_tangle import *

--- a/iota/commands/core/add_neighbors.py
+++ b/iota/commands/core/add_neighbors.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota.commands import FilterCommand, RequestFilter

--- a/iota/commands/core/attach_to_tangle.py
+++ b/iota/commands/core/attach_to_tangle.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionHash, TransactionTrytes

--- a/iota/commands/core/broadcast_transactions.py
+++ b/iota/commands/core/broadcast_transactions.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionTrytes

--- a/iota/commands/core/check_consistency.py
+++ b/iota/commands/core/check_consistency.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionHash

--- a/iota/commands/core/find_transactions.py
+++ b/iota/commands/core/find_transactions.py
@@ -1,9 +1,4 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
-from six import iteritems
 
 from iota import BundleHash, Tag, TransactionHash
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
@@ -70,7 +65,7 @@ class FindTransactionsRequestFilter(RequestFilter):
         # https://github.com/iotaledger/iota.py/issues/96
         search_terms = {
             term: query
-            for term, query in iteritems(value)
+            for term, query in value.items()
             if query is not None
         }
 

--- a/iota/commands/core/get_balances.py
+++ b/iota/commands/core/get_balances.py
@@ -1,9 +1,4 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
-from six import iteritems
 
 from iota import TransactionHash
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
@@ -66,7 +61,7 @@ class GetBalancesRequestFilter(RequestFilter):
         # Note: We will assume that empty lists are intentional.
         search_terms = {
             term: query
-            for term, query in iteritems(value)
+            for term, query in value.items()
             if query is not None
         }
 

--- a/iota/commands/core/get_inclusion_states.py
+++ b/iota/commands/core/get_inclusion_states.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionHash

--- a/iota/commands/core/get_missing_transactions.py
+++ b/iota/commands/core/get_missing_transactions.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionHash

--- a/iota/commands/core/get_neighbors.py
+++ b/iota/commands/core/get_neighbors.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from iota.commands import FilterCommand, RequestFilter
 
 __all__ = [

--- a/iota/commands/core/get_node_api_configuration.py
+++ b/iota/commands/core/get_node_api_configuration.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from iota.commands import FilterCommand, RequestFilter
 
 __all__ = [

--- a/iota/commands/core/get_node_info.py
+++ b/iota/commands/core/get_node_info.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionHash

--- a/iota/commands/core/get_tips.py
+++ b/iota/commands/core/get_tips.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter

--- a/iota/commands/core/get_transactions_to_approve.py
+++ b/iota/commands/core/get_transactions_to_approve.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionHash

--- a/iota/commands/core/get_trytes.py
+++ b/iota/commands/core/get_trytes.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionHash

--- a/iota/commands/core/interrupt_attaching_to_tangle.py
+++ b/iota/commands/core/interrupt_attaching_to_tangle.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from iota.commands import FilterCommand, RequestFilter
 
 __all__ = [

--- a/iota/commands/core/remove_neighbors.py
+++ b/iota/commands/core/remove_neighbors.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota.commands import FilterCommand, RequestFilter

--- a/iota/commands/core/store_transactions.py
+++ b/iota/commands/core/store_transactions.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import TransactionTrytes

--- a/iota/commands/core/were_addresses_spent_from.py
+++ b/iota/commands/core/were_addresses_spent_from.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota.commands import FilterCommand, RequestFilter

--- a/iota/commands/extended/__init__.py
+++ b/iota/commands/extended/__init__.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 """
 Extended API commands encapsulate the core commands and provide
 additional functionality such as address generation and signatures.
@@ -8,8 +7,6 @@ References:
 - ht§tps://github.com/iotaledger/wiki/blob/master/api-proposal.md
 """
 
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 from .broadcast_and_store import *
 from .broadcast_bundle import *

--- a/iota/commands/extended/broadcast_and_store.py
+++ b/iota/commands/extended/broadcast_and_store.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from iota.commands import FilterCommand
 from iota.commands.core.broadcast_transactions import \
     BroadcastTransactionsCommand

--- a/iota/commands/extended/broadcast_bundle.py
+++ b/iota/commands/extended/broadcast_bundle.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 from iota.filters import Trytes
 

--- a/iota/commands/extended/find_transaction_objects.py
+++ b/iota/commands/extended/find_transaction_objects.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Iterable, List, Optional
 
 from iota import Address, BundleHash, Tag, Transaction, TransactionHash

--- a/iota/commands/extended/get_account_data.py
+++ b/iota/commands/extended/get_account_data.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from operator import attrgetter
 from typing import List, Optional
 
@@ -117,7 +113,6 @@ class GetAccountDataRequestFilter(RequestFilter):
         )
 
     def _apply(self, value):
-        # noinspection PyProtectedMember
         filtered = super(GetAccountDataRequestFilter, self)._apply(value)
 
         if self._has_errors:

--- a/iota/commands/extended/get_bundles.py
+++ b/iota/commands/extended/get_bundles.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import BadApiResponse, TransactionHash

--- a/iota/commands/extended/get_inputs.py
+++ b/iota/commands/extended/get_inputs.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Optional
 
 import filters as f

--- a/iota/commands/extended/get_latest_inclusion.py
+++ b/iota/commands/extended/get_latest_inclusion.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List
 
 import filters as f

--- a/iota/commands/extended/get_new_addresses.py
+++ b/iota/commands/extended/get_new_addresses.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List, Optional
 
 import filters as f

--- a/iota/commands/extended/get_transaction_objects.py
+++ b/iota/commands/extended/get_transaction_objects.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Iterable, List, Optional
 
 import filters as f

--- a/iota/commands/extended/get_transfers.py
+++ b/iota/commands/extended/get_transfers.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from itertools import chain
 from typing import Optional
 
@@ -100,7 +96,6 @@ class GetTransfersRequestFilter(RequestFilter):
         )
 
     def _apply(self, value):
-        # noinspection PyProtectedMember
         filtered = super(GetTransfersRequestFilter, self)._apply(value)
 
         if self._has_errors:

--- a/iota/commands/extended/is_promotable.py
+++ b/iota/commands/extended/is_promotable.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from iota.commands import FilterCommand, RequestFilter
 from iota.commands.core import CheckConsistencyCommand, GetTrytesCommand
 from iota.transaction import Transaction

--- a/iota/commands/extended/is_reattachable.py
+++ b/iota/commands/extended/is_reattachable.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List
 
 import filters as f

--- a/iota/commands/extended/prepare_transfer.py
+++ b/iota/commands/extended/prepare_transfer.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List, Optional
 
 import filters as f

--- a/iota/commands/extended/promote_transaction.py
+++ b/iota/commands/extended/promote_transaction.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import Address, BadApiResponse, ProposedTransaction, TransactionHash

--- a/iota/commands/extended/replay_bundle.py
+++ b/iota/commands/extended/replay_bundle.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import filters as f
 
 from iota import Bundle, TransactionHash

--- a/iota/commands/extended/send_transfer.py
+++ b/iota/commands/extended/send_transfer.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List, Optional
 
 import filters as f

--- a/iota/commands/extended/send_trytes.py
+++ b/iota/commands/extended/send_trytes.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List, Optional
 
 import filters as f

--- a/iota/commands/extended/traverse_bundle.py
+++ b/iota/commands/extended/traverse_bundle.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List, Optional
 
 import filters as f

--- a/iota/commands/extended/utils.py
+++ b/iota/commands/extended/utils.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Generator, Iterable, List, Optional, Tuple
 
 from iota import Address, Bundle, Transaction, \

--- a/iota/crypto/__init__.py
+++ b/iota/crypto/__init__.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 # Load curl library.
 # If a compiled c extension is available, we will prefer to load that;
 # otherwise fall back to pure-Python implementation.

--- a/iota/crypto/addresses.py
+++ b/iota/crypto/addresses.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Generator, Iterable, List
 
 from iota import Address, TRITS_PER_TRYTE, TrytesCompatible

--- a/iota/crypto/kerl/__init__.py
+++ b/iota/crypto/kerl/__init__.py
@@ -1,5 +1,1 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from .pykerl import *

--- a/iota/crypto/kerl/conv.py
+++ b/iota/crypto/kerl/conv.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 BYTE_HASH_LENGTH = 48
 TRIT_HASH_LENGTH = 243
 

--- a/iota/crypto/kerl/pykerl.py
+++ b/iota/crypto/kerl/pykerl.py
@@ -1,11 +1,6 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import MutableSequence, Optional
 
 from sha3 import keccak_384
-from six import PY2
 
 from iota.crypto.kerl import conv
 from iota.exceptions import with_context
@@ -121,9 +116,6 @@ class Kerl(object):
 
         while offset < length:
             unsigned_hash = self.k.digest()
-
-            if PY2:
-                unsigned_hash = map(ord, unsigned_hash)  # type: ignore
 
             signed_hash = [conv.convert_sign(b) for b in unsigned_hash]
 

--- a/iota/crypto/pycurl.py
+++ b/iota/crypto/pycurl.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List, MutableSequence, Optional, Sequence
 
 from iota.exceptions import with_context
@@ -53,7 +49,6 @@ class Curl(object):
         # type: (Optional[Sequence[int]]) -> None
         self.reset()
 
-    # noinspection PyAttributeOutsideInit
     def reset(self):
         # type: () -> None
         """

--- a/iota/crypto/signing.py
+++ b/iota/crypto/signing.py
@@ -1,10 +1,4 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Iterator, List, Sequence
-
-from six import PY2
 
 from iota import Hash, TRITS_PER_TRYTE, TryteString, TrytesCompatible
 from iota.crypto import FRAGMENT_LENGTH, HASH_LENGTH
@@ -304,9 +298,6 @@ class KeyIterator(Iterator[PrivateKey]):
 
             return private_key
 
-    if PY2:
-        next = __next__
-
     def advance(self):
         """
         Advances the generator without creating a key.
@@ -395,10 +386,6 @@ class SignatureFragmentGenerator(Iterator[TryteString]):
             signature_fragment[hash_start:hash_end] = buffer
 
         return TryteString.from_trits(signature_fragment)
-
-    if PY2:
-        next = __next__
-
 
 def validate_signature_fragments(
         fragments,

--- a/iota/crypto/types.py
+++ b/iota/crypto/types.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 import warnings
 from typing import Optional
 

--- a/iota/exceptions.py
+++ b/iota/exceptions.py
@@ -1,6 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 __all__ = [
     'with_context',

--- a/iota/filters.py
+++ b/iota/filters.py
@@ -1,12 +1,8 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Text, Type
 
 import filters as f
 from filters.macros import filter_macro
-from six import binary_type, moves as compat, text_type
+from urllib.parse import urlparse
 
 from iota import Address, TryteString, TrytesCompatible
 from iota.crypto.addresses import AddressGenerator
@@ -81,12 +77,12 @@ class NodeUri(f.BaseFilter):
     }
 
     def _apply(self, value):
-        value = self._filter(value, f.Type(text_type))  # type: Text
+        value = self._filter(value, f.Type(str))  # type: Text
 
         if self._has_errors:
             return None
 
-        parsed = compat.urllib_parse.urlparse(value)
+        parsed = urlparse(value)
 
         if parsed.scheme not in self.SCHEMES:
             return self._invalid_value(value, self.CODE_NOT_NODE_URI)
@@ -94,7 +90,6 @@ class NodeUri(f.BaseFilter):
         return value
 
 
-# noinspection PyPep8Naming
 @filter_macro
 def SecurityLevel():
     """
@@ -164,10 +159,9 @@ class Trytes(f.BaseFilter):
         self.result_type = result_type
 
     def _apply(self, value):
-        # noinspection PyTypeChecker
         value = self._filter(
             filter_chain=f.Type(
-                (binary_type, bytearray, text_type, TryteString)
+                (bytes, bytearray, str, TryteString)
             ),
 
             value=value,
@@ -211,7 +205,6 @@ class Trytes(f.BaseFilter):
             )
 
 
-# noinspection PyPep8Naming
 @filter_macro
 def StringifiedTrytesArray(trytes_type=TryteString):
     # type: (Type[TryteString]) -> f.FilterChain

--- a/iota/json.py
+++ b/iota/json.py
@@ -1,16 +1,9 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from abc import ABCMeta, abstractmethod as abstract_method
 from json.encoder import JSONEncoder as BaseJsonEncoder
 from typing import Iterable, Mapping
 
-from six import add_metaclass
 
-
-@add_metaclass(ABCMeta)
-class JsonSerializable(object):
+class JsonSerializable(object, metaclass=ABCMeta):
     """
     Interface for classes that can be safely converted to JSON.
     """

--- a/iota/multisig/__init__.py
+++ b/iota/multisig/__init__.py
@@ -1,5 +1,1 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from .api import *

--- a/iota/multisig/api.py
+++ b/iota/multisig/api.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Iterable, Optional
 
 from iota import Address, Iota, AsyncIota, ProposedTransaction

--- a/iota/multisig/commands/__init__.py
+++ b/iota/multisig/commands/__init__.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from .create_multisig_address import *
 from .get_digests import *
 from .get_private_keys import *

--- a/iota/multisig/commands/create_multisig_address.py
+++ b/iota/multisig/commands/create_multisig_address.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List
 
 import filters as f

--- a/iota/multisig/commands/get_digests.py
+++ b/iota/multisig/commands/get_digests.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Optional
 
 import filters as f

--- a/iota/multisig/commands/get_private_keys.py
+++ b/iota/multisig/commands/get_private_keys.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Optional
 
 import filters as f

--- a/iota/multisig/commands/prepare_multisig_transfer.py
+++ b/iota/multisig/commands/prepare_multisig_transfer.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List, Optional
 
 import filters as f

--- a/iota/multisig/crypto/__init__.py
+++ b/iota/multisig/crypto/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals

--- a/iota/multisig/crypto/addresses.py
+++ b/iota/multisig/crypto/addresses.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import List, Optional
 
 from iota.crypto import HASH_LENGTH

--- a/iota/multisig/transaction.py
+++ b/iota/multisig/transaction.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from typing import Iterable
 
 from iota import ProposedBundle

--- a/iota/multisig/types.py
+++ b/iota/multisig/types.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from operator import attrgetter
 from typing import Iterable, Optional
 

--- a/iota/transaction/__init__.py
+++ b/iota/transaction/__init__.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 # Import symbols to package namespace, for backwards-compatibility with
 # PyOTA 1.1.x.
 from .base import *

--- a/iota/transaction/base.py
+++ b/iota/transaction/base.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from operator import attrgetter
 from typing import Iterable, Iterator, List, MutableSequence, \
     Optional, Sequence, Text

--- a/iota/transaction/creation.py
+++ b/iota/transaction/creation.py
@@ -1,10 +1,4 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Iterable, Iterator, List, Optional, Sequence
-
-from six import PY2
 
 from iota.crypto import HASH_LENGTH
 from iota.crypto.kerl import Kerl
@@ -215,10 +209,6 @@ class ProposedBundle(Bundle, Sequence[ProposedTransaction]):
         :return: ``bool``
         """
         return bool(self._transactions)
-
-    # :bc: Magic methods have different names in Python 2.
-    if PY2:
-        __nonzero__ = __bool__
 
     def __contains__(self, transaction):
         # type: (ProposedTransaction) -> bool

--- a/iota/transaction/types.py
+++ b/iota/transaction/types.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from iota.crypto import FRAGMENT_LENGTH
 from iota.exceptions import with_context
 from iota.types import Hash, TryteString, TrytesCompatible

--- a/iota/transaction/utils.py
+++ b/iota/transaction/utils.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from calendar import timegm as unix_timestamp
 from datetime import datetime
 from typing import Text

--- a/iota/transaction/validator.py
+++ b/iota/transaction/validator.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from typing import Generator, List, Optional, Text
 
 from iota.crypto.kerl import Kerl
@@ -210,7 +206,6 @@ class BundleValidator(object):
         # algo).
         if current_errors and LEGACY_SPONGE:
             for group in groups:
-                # noinspection PyTypeChecker
                 if self._get_group_signature_error(group, LEGACY_SPONGE):
                     # Legacy algo doesn't work, either; no point in
                     # continuing.

--- a/iota/trits.py
+++ b/iota/trits.py
@@ -1,13 +1,9 @@
-# coding=utf-8
 """
 Provides functions for manipulating sequences of trits.
 
 Based on
 https://github.com/iotaledger/iota.lib.js/blob/v0.4.2/lib/crypto/helpers/adder.js
 """
-
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
 
 from typing import Iterable, List, Optional, Sequence, Tuple
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-# coding=utf-8
-# :bc: Not importing unicode_literals because in Python 2 distutils,
-# some values are expected to be byte strings.
-from __future__ import absolute_import, division, print_function
 
 from codecs import StreamReader, open
 from distutils.version import LooseVersion
@@ -12,11 +8,11 @@ import setuptools
 ##
 # Because of the way PyOTA declares its dependencies, it requires a
 # more recent version of setuptools.
-# https://www.python.org/dev/peps/pep-0508/#environment-markers
-if LooseVersion(setuptools.__version__) < LooseVersion('20.5'):
+# https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+if LooseVersion(setuptools.__version__) < LooseVersion('24.2'):
     import sys
 
-    sys.exit('Installation failed: Upgrade setuptools to version 20.5 or later')
+    sys.exit('Installation failed: Upgrade setuptools to version 24.2 or later')
 
 ##
 # Load long description for PyPI.
@@ -29,13 +25,11 @@ with open('docs/README.rst', 'r', 'utf-8') as f:  # type: StreamReader
 # (``pip install -e .[test-runner]``).
 tests_require = [
     'aiounittest',
-    'mock; python_version < "3.0"',
     'nose',
 ]
 
 ##
 # Off we go!
-# noinspection SpellCheckingInspection
 setuptools.setup(
     name='PyOTA',
     description='IOTA API library for Python',
@@ -58,16 +52,22 @@ setuptools.setup(
         ],
     },
 
+    # Tell setuptools which python versions to support. Will include metadata
+    # in the built sdist and wheel that tells pypi to tell pip about supported
+    # python versions.
+    # 'python_requires' works from setuptools 24.2.0 (previous versions ignore
+    # it with a warning), pip understands it from 9.0.0.
+    # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+    python_requires='>=3.6, <4',
+
     # filters is no longer maintained and does not support Python 3.7
     # phx-filters is a fork that supports 3.7 and 3.8 but not 2.7
 
     install_requires=[
-        'filters; python_version < "3.5"',
         'httpx',
-        'phx-filters; python_version >= "3.5"',
+        'phx-filters',
         'pysha3',
         'six',
-        'typing; python_version < "3.0"',
     ],
 
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setuptools.setup(
         'httpx',
         'phx-filters',
         'pysha3',
-        'six',
     ],
 
     extras_require={

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,19 +1,5 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
-from six import PY3
-
-if PY3:
-  # In Python 3 the ``mock`` library was moved into the stdlib.
-  # noinspection PyUnresolvedReferences
-  from unittest import mock
-  from unittest.mock import MagicMock, patch
-else:
-  # In Python 2, the ``mock`` library is included as a dependency.
-  # noinspection PyUnresolvedReferences
-  import mock
-  from mock import MagicMock, patch
+from unittest import mock
+from unittest.mock import MagicMock, patch
 
 # Executes async test case within a loop
 from aiounittest import async_test

--- a/test/adapter/__init__.py
+++ b/test/adapter/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/adapter/wrappers_test.py
+++ b/test/adapter/wrappers_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota.adapter import HttpAdapter, MockAdapter

--- a/test/adapter_test.py
+++ b/test/adapter_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 import json
 import socket
 from typing import Text
@@ -11,7 +7,6 @@ import httpx
 from iota import BadApiResponse, InvalidUri, TryteString
 from iota.adapter import API_VERSION, HttpAdapter, MockAdapter, \
   resolve_adapter, async_return
-from six import BytesIO, text_type
 from test import mock, async_test
 
 class ResolveAdapterTestCase(TestCase):
@@ -143,7 +138,6 @@ class HttpAdapterTestCase(TestCase):
     mocked_response = create_http_response(json.dumps(expected_result))
     mocked_sender   = mock.Mock(return_value=async_return(mocked_response))
 
-    # noinspection PyUnresolvedReferences
     with mock.patch.object(adapter, '_send_http_request', mocked_sender):
       result = await adapter.send_request(payload)
 
@@ -181,7 +175,6 @@ class HttpAdapterTestCase(TestCase):
 
     mocked_sender = mock.Mock(return_value=async_return(mocked_response))
 
-    # noinspection PyUnresolvedReferences
     with mock.patch.object(adapter, '_send_http_request', mocked_sender):
       with self.assertRaises(BadApiResponse) as context:
         await adapter.send_request({'command': 'helloWorld'})
@@ -212,13 +205,12 @@ class HttpAdapterTestCase(TestCase):
 
     mocked_sender = mock.Mock(return_value=async_return(mocked_response))
 
-    # noinspection PyUnresolvedReferences
     with mock.patch.object(adapter, '_send_http_request', mocked_sender):
       with self.assertRaises(BadApiResponse) as context:
         await adapter.send_request({'command': 'helloWorld'})
 
     self.assertEqual(
-      text_type(context.exception),
+      str(context.exception),
       '500 response from node: {error}'.format(error=error_message),
     )
 
@@ -239,13 +231,12 @@ class HttpAdapterTestCase(TestCase):
 
     mocked_sender = mock.Mock(return_value=async_return(mocked_response))
 
-    # noinspection PyUnresolvedReferences
     with mock.patch.object(adapter, '_send_http_request', mocked_sender):
       with self.assertRaises(BadApiResponse) as context:
         await adapter.send_request({'command': 'helloWorld'})
 
     self.assertEqual(
-      text_type(context.exception),
+      str(context.exception),
       '429 response from node: {decoded}'.format(decoded=decoded_response),
     )
 
@@ -260,13 +251,12 @@ class HttpAdapterTestCase(TestCase):
 
     mocked_sender = mock.Mock(return_value=async_return(mocked_response))
 
-    # noinspection PyUnresolvedReferences
     with mock.patch.object(adapter, '_send_http_request', mocked_sender):
       with self.assertRaises(BadApiResponse) as context:
         await adapter.send_request({'command': 'helloWorld'})
 
     self.assertEqual(
-      text_type(context.exception),
+      str(context.exception),
       'Empty 200 response from node.',
     )
 
@@ -282,13 +272,12 @@ class HttpAdapterTestCase(TestCase):
 
     mocked_sender = mock.Mock(return_value=async_return(mocked_response))
 
-    # noinspection PyUnresolvedReferences
     with mock.patch.object(adapter, '_send_http_request', mocked_sender):
       with self.assertRaises(BadApiResponse) as context:
         await adapter.send_request({'command': 'helloWorld'})
 
     self.assertEqual(
-      text_type(context.exception),
+      str(context.exception),
       'Non-JSON 200 response from node: ' + invalid_response,
     )
 
@@ -304,13 +293,12 @@ class HttpAdapterTestCase(TestCase):
 
     mocked_sender = mock.Mock(return_value=async_return(mocked_response))
 
-    # noinspection PyUnresolvedReferences
     with mock.patch.object(adapter, '_send_http_request', mocked_sender):
       with self.assertRaises(BadApiResponse) as context:
         await adapter.send_request({'command': 'helloWorld'})
 
     self.assertEqual(
-      text_type(context.exception),
+      str(context.exception),
 
       'Malformed 200 response from node: {response!r}'.format(
         response = invalid_response,
@@ -330,7 +318,6 @@ class HttpAdapterTestCase(TestCase):
       )
     )
 
-    # noinspection PyUnresolvedReferences
     with mock.patch('iota.adapter.AsyncClient.request', mocked_request):
       # test with default timeout
       await adapter.send_request(payload=mock_payload)
@@ -399,7 +386,6 @@ class HttpAdapterTestCase(TestCase):
     _, kwargs = mocked_request.call_args
     self.assertEqual(kwargs['timeout'], 99)
 
-  # noinspection SpellCheckingInspection
   @async_test
   async def test_trytes_in_request(self):
     """
@@ -411,7 +397,6 @@ class HttpAdapterTestCase(TestCase):
     # sure that the request is converted correctly.
     mocked_sender = mock.Mock(return_value=async_return(create_http_response('{}')))
 
-    # noinspection PyUnresolvedReferences
     with mock.patch.object(adapter, '_send_http_request', mocked_sender):
       await adapter.send_request({
         'command':  'helloWorld',

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -1,11 +1,5 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from abc import ABCMeta
 from unittest import TestCase
-
-from six import add_metaclass
 
 from iota import InvalidCommand, StrictIota
 from iota.adapter import MockAdapter
@@ -133,7 +127,5 @@ class IotaApiTestCase(TestCase):
         """
         # This statement will raise an exception if the regression is
         # present; no assertions necessary.
-        # noinspection PyUnusedLocal
-        @add_metaclass(ABCMeta)
-        class CustomClient(object):
+        class CustomClient(object, metaclass=ABCMeta):
             client = StrictIota(MockAdapter())

--- a/test/codecs_test.py
+++ b/test/codecs_test.py
@@ -1,17 +1,10 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from codecs import decode, encode
 from unittest import TestCase
 from warnings import catch_warnings, simplefilter as simple_filter
 
-from six import text_type
-
 from iota.codecs import AsciiTrytesCodec, TrytesDecodeError
 
 
-# noinspection SpellCheckingInspection
 class AsciiTrytesCodecTestCase(TestCase):
   def test_encode_byte_string(self):
     """
@@ -134,4 +127,4 @@ class AsciiTrytesCodecTestCase(TestCase):
 
     self.assertEqual(len(warnings), 1)
     self.assertEqual(warnings[0].category, DeprecationWarning)
-    self.assertIn('codec will be removed', text_type(warnings[0].message))
+    self.assertIn('codec will be removed', str(warnings[0].message))

--- a/test/commands/__init__.py
+++ b/test/commands/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/commands/core/__init__.py
+++ b/test/commands/core/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/commands/core/add_neighbors_test.py
+++ b/test/commands/core/add_neighbors_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f

--- a/test/commands/core/attach_to_tangle_test.py
+++ b/test/commands/core/attach_to_tangle_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -11,7 +7,6 @@ from iota import Iota, TransactionHash, TransactionTrytes, TryteString, \
 from iota.adapter import MockAdapter, async_return
 from iota.commands.core.attach_to_tangle import AttachToTangleCommand
 from iota.filters import Trytes
-from six import binary_type, text_type
 from test import patch, MagicMock, async_test
 
 
@@ -19,7 +14,6 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
   filter_type = AttachToTangleCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(AttachToTangleRequestFilterTestCase, self).setUp()
 
@@ -39,14 +33,14 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
     The incoming request is valid.
     """
     request = {
-      'trunkTransaction':   text_type(TransactionHash(self.txn_id)),
-      'branchTransaction':  text_type(TransactionHash(self.txn_id)),
+      'trunkTransaction':   str(TransactionHash(self.txn_id)),
+      'branchTransaction':  str(TransactionHash(self.txn_id)),
       'minWeightMagnitude': 20,
 
       'trytes': [
         # Raw trytes are extracted to match the IRI's JSON protocol.
-        text_type(TransactionTrytes(self.trytes1)),
-        text_type(TransactionTrytes(self.trytes2)),
+        str(TransactionTrytes(self.trytes1)),
+        str(TransactionTrytes(self.trytes2)),
       ],
     }
 
@@ -55,7 +49,6 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
     self.assertFilterPasses(filter_)
     self.assertDictEqual(filter_.cleaned_data, request)
 
-  # noinspection SpellCheckingInspection
   def test_pass_compatible_types(self):
     """
     Incoming values can be converted into the expected types.
@@ -69,7 +62,7 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
       'trytes': [
         # ``trytes`` can contain any value that can be converted into a
         # TryteString.
-        binary_type(TransactionTrytes(self.trytes1)),
+        bytes(TransactionTrytes(self.trytes1)),
 
         # This is probably wrong (s/b :py:class:`TransactionTrytes`),
         # but technically it's valid.
@@ -94,9 +87,9 @@ class AttachToTangleRequestFilterTestCase(BaseFilterTestCase):
         'minWeightMagnitude': 30,
 
         'trytes':               [
-          text_type(TransactionTrytes(self.trytes1)),
+          str(TransactionTrytes(self.trytes1)),
 
-          text_type(TransactionTrytes(
+          str(TransactionTrytes(
             b'CCPCBDVC9DTCEAKDXC9D9DEARCWCPCBDVCTCEAHD'
             b'WCTCEAKDCDFD9DSCSA99999999999999999999999',
           )),
@@ -386,7 +379,6 @@ class AttachToTangleResponseFilterTestCase(BaseFilterTestCase):
   filter_type = AttachToTangleCommand(MockAdapter()).get_response_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(AttachToTangleResponseFilterTestCase, self).setUp()
 

--- a/test/commands/core/broadcast_transactions_test.py
+++ b/test/commands/core/broadcast_transactions_test.py
@@ -1,12 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type, text_type
 
 from iota import Iota, AsyncIota, TransactionTrytes, TryteString
 from iota.adapter import MockAdapter, async_return
@@ -19,7 +14,6 @@ class BroadcastTransactionsRequestFilterTestCase(BaseFilterTestCase):
   filter_type = BroadcastTransactionsCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(BroadcastTransactionsRequestFilterTestCase, self).setUp()
 
@@ -36,8 +30,8 @@ class BroadcastTransactionsRequestFilterTestCase(BaseFilterTestCase):
     """
     request = {
       'trytes': [
-        text_type(self.trytes1),
-        text_type(self.trytes2),
+        str(self.trytes1),
+        str(self.trytes2),
       ],
     }
 
@@ -54,7 +48,7 @@ class BroadcastTransactionsRequestFilterTestCase(BaseFilterTestCase):
     # Any values that can be converted into TryteStrings are accepted.
     filter_ = self._filter({
       'trytes': [
-        binary_type(self.trytes1),
+        bytes(self.trytes1),
         self.trytes2,
       ],
     })
@@ -66,8 +60,8 @@ class BroadcastTransactionsRequestFilterTestCase(BaseFilterTestCase):
       {
         'trytes': [
           # Raw trytes are extracted to match the IRI's JSON protocol.
-          text_type(self.trytes1),
-          text_type(self.trytes2),
+          str(self.trytes1),
+          str(self.trytes2),
         ],
       },
     )

--- a/test/commands/core/check_consistency_test.py
+++ b/test/commands/core/check_consistency_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -18,7 +14,6 @@ class CheckConsistencyRequestFilterTestCase(BaseFilterTestCase):
     filter_type = CheckConsistencyCommand(MockAdapter()).get_request_filter
     skip_value_check = True
 
-    # noinspection SpellCheckingInspection
     def setUp(self):
         super(CheckConsistencyRequestFilterTestCase, self).setUp()
 
@@ -172,7 +167,6 @@ class CheckConsistencyRequestFilterTestCase(BaseFilterTestCase):
 
 
 class CheckConsistencyCommandTestCase(TestCase):
-    # noinspection SpellCheckingInspection
     def setUp(self):
         super(CheckConsistencyCommandTestCase, self).setUp()
 

--- a/test/commands/core/find_transactions_test.py
+++ b/test/commands/core/find_transactions_test.py
@@ -1,12 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import text_type
 
 from iota import Address, Iota, Tag, BundleHash, TransactionHash, TryteString, \
   AsyncIota
@@ -21,7 +16,6 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
   filter_type = FindTransactionsCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(FindTransactionsRequestFilterTestCase, self).setUp()
 
@@ -38,23 +32,23 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
     # Raw trytes are extracted to match the IRI's JSON protocol.
     request = {
       'bundles': [
-        text_type(BundleHash(self.trytes1)),
-        text_type(BundleHash(self.trytes2)),
+        str(BundleHash(self.trytes1)),
+        str(BundleHash(self.trytes2)),
       ],
 
       'addresses': [
-        text_type(Address(self.trytes1)),
-        text_type(Address(self.trytes2)),
+        str(Address(self.trytes1)),
+        str(Address(self.trytes2)),
       ],
 
       'tags': [
-        text_type(Tag(self.trytes1)),
-        text_type(Tag(self.trytes3)),
+        str(Tag(self.trytes1)),
+        str(Tag(self.trytes3)),
       ],
 
       'approvees': [
-        text_type(TransactionHash(self.trytes1)),
-        text_type(TransactionHash(self.trytes3)),
+        str(TransactionHash(self.trytes1)),
+        str(TransactionHash(self.trytes3)),
       ],
     }
 
@@ -97,23 +91,23 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
       {
         # Raw trytes are extracted to match the IRI's JSON protocol.
         'bundles': [
-          text_type(BundleHash(self.trytes1)),
-          text_type(BundleHash(self.trytes2)),
+          str(BundleHash(self.trytes1)),
+          str(BundleHash(self.trytes2)),
         ],
 
         'addresses': [
-          text_type(Address(self.trytes1)),
-          text_type(Address(self.trytes2)),
+          str(Address(self.trytes1)),
+          str(Address(self.trytes2)),
         ],
 
         'tags': [
-          text_type(Tag(self.trytes1)),
-          text_type(Tag(self.trytes3)),
+          str(Tag(self.trytes1)),
+          str(Tag(self.trytes3)),
         ],
 
         'approvees': [
-          text_type(TransactionHash(self.trytes1)),
-          text_type(TransactionHash(self.trytes3)),
+          str(TransactionHash(self.trytes1)),
+          str(TransactionHash(self.trytes3)),
         ],
       },
     )
@@ -137,8 +131,8 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
 
       {
         'bundles': [
-          text_type(BundleHash(self.trytes1)),
-          text_type(BundleHash(self.trytes2)),
+          str(BundleHash(self.trytes1)),
+          str(BundleHash(self.trytes2)),
         ],
 
         # Null criteria are not included in the request.
@@ -168,8 +162,8 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
 
       {
         'addresses': [
-          text_type(Address(self.trytes1)),
-          text_type(Address(self.trytes2)),
+          str(Address(self.trytes1)),
+          str(Address(self.trytes2)),
         ],
 
         # Null criteria are not included in the request.
@@ -199,8 +193,8 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
 
       {
         'tags': [
-          text_type(Tag(self.trytes1)),
-          text_type(Tag(self.trytes3)),
+          str(Tag(self.trytes1)),
+          str(Tag(self.trytes3)),
         ],
 
         # Null criteria are not included in the request.
@@ -230,8 +224,8 @@ class FindTransactionsRequestFilterTestCase(BaseFilterTestCase):
 
       {
         'approvees': [
-          text_type(TransactionHash(self.trytes1)),
-          text_type(TransactionHash(self.trytes3)),
+          str(TransactionHash(self.trytes1)),
+          str(TransactionHash(self.trytes3)),
         ],
 
         # Null criteria are not included in the request.
@@ -491,7 +485,6 @@ class FindTransactionsResponseFilterTestCase(BaseFilterTestCase):
   filter_type = FindTransactionsCommand(MockAdapter()).get_response_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(FindTransactionsResponseFilterTestCase, self).setUp()
 
@@ -515,7 +508,6 @@ class FindTransactionsResponseFilterTestCase(BaseFilterTestCase):
     self.assertFilterPasses(filter_)
     self.assertDictEqual(filter_.cleaned_data, response)
 
-  # noinspection SpellCheckingInspection
   def test_search_results(self):
     """
     The incoming response contains lots of hashes.

--- a/test/commands/core/get_balances_test.py
+++ b/test/commands/core/get_balances_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -18,7 +14,6 @@ class GetBalancesRequestFilterTestCase(BaseFilterTestCase):
     filter_type = GetBalancesCommand(MockAdapter()).get_request_filter
     skip_value_check = True
 
-    # noinspection SpellCheckingInspection
     def setUp(self):
         super(GetBalancesRequestFilterTestCase, self).setUp()
 
@@ -305,7 +300,6 @@ class GetBalancesRequestFilterTestCase(BaseFilterTestCase):
         )
 
 
-# noinspection SpellCheckingInspection
 class GetBalancesResponseFilterTestCase(BaseFilterTestCase):
     filter_type = GetBalancesCommand(MockAdapter()).get_response_filter
     skip_value_check = True

--- a/test/commands/core/get_inclusion_states_test.py
+++ b/test/commands/core/get_inclusion_states_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -10,7 +6,6 @@ from iota import Iota, TransactionHash, TryteString, AsyncIota
 from iota.adapter import MockAdapter, async_return
 from iota.commands.core.get_inclusion_states import GetInclusionStatesCommand
 from iota.filters import Trytes
-from six import binary_type, text_type
 from test import patch, MagicMock, async_test
 
 
@@ -18,7 +13,6 @@ class GetInclusionStatesRequestFilterTestCase(BaseFilterTestCase):
   filter_type = GetInclusionStatesCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetInclusionStatesRequestFilterTestCase, self).setUp()
 

--- a/test/commands/core/get_missing_transactions_test.py
+++ b/test/commands/core/get_missing_transactions_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -50,7 +46,6 @@ class GetMissingTransactionsResponseFilterTestCase(BaseFilterTestCase):
         GetMissingTransactionsCommand(MockAdapter()).get_response_filter
     skip_value_check = True
 
-    # noinspection SpellCheckingInspection
     def test_no_results(self):
         """
         The incoming response contains no hashes.
@@ -64,7 +59,6 @@ class GetMissingTransactionsResponseFilterTestCase(BaseFilterTestCase):
         self.assertFilterPasses(filter_)
         self.assertDictEqual(filter_.cleaned_data, response)
 
-    # noinspection SpellCheckingInspection
     def test_search_results(self):
         """
         The incoming response contains lots of hashes.

--- a/test/commands/core/get_neighbors_test.py
+++ b/test/commands/core/get_neighbors_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f

--- a/test/commands/core/get_node_api_configuration_test.py
+++ b/test/commands/core/get_node_api_configuration_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f

--- a/test/commands/core/get_node_info_test.py
+++ b/test/commands/core/get_node_info_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -47,7 +43,6 @@ class GetNodeInfoResponseFilterTestCase(BaseFilterTestCase):
   filter_type = GetNodeInfoCommand(MockAdapter()).get_response_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def test_pass_happy_path(self):
     """
     The incoming response contains valid values.

--- a/test/commands/core/get_tips_test.py
+++ b/test/commands/core/get_tips_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -49,7 +45,6 @@ class GetTipsResponseFilterTestCase(BaseFilterTestCase):
   filter_type = GetTipsCommand(MockAdapter()).get_response_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def test_pass_lots_of_hashes(self):
     """
     The response contains lots of hashes.
@@ -167,7 +162,6 @@ class GetTipsCommandTestCase(TestCase):
 
     https://github.com/iotaledger/iota.py/issues/130
     """
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('getTips', {
       'duration': 42,
       'hashes': [

--- a/test/commands/core/get_transactions_to_approve_test.py
+++ b/test/commands/core/get_transactions_to_approve_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -178,7 +174,6 @@ class GetTransactionsToApproveResponseFilterTestCase(BaseFilterTestCase):
         GetTransactionsToApproveCommand(MockAdapter()).get_response_filter
     skip_value_check = True
 
-    # noinspection SpellCheckingInspection
     def test_pass_happy_path(self):
         """
         Typical ``getTransactionsToApprove`` response.

--- a/test/commands/core/get_trytes_test.py
+++ b/test/commands/core/get_trytes_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -18,7 +14,6 @@ class GetTrytesRequestFilterTestCase(BaseFilterTestCase):
   filter_type = GetTrytesCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetTrytesRequestFilterTestCase, self).setUp()
 
@@ -180,7 +175,6 @@ class GetTrytesResponseFilter(BaseFilterTestCase):
   filter_type = GetTrytesCommand(MockAdapter()).get_response_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetTrytesResponseFilter, self).setUp()
 

--- a/test/commands/core/interrupt_attaching_to_tangle_test.py
+++ b/test/commands/core/interrupt_attaching_to_tangle_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f

--- a/test/commands/core/remove_neighbors_test.py
+++ b/test/commands/core/remove_neighbors_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f

--- a/test/commands/core/store_transactions_test.py
+++ b/test/commands/core/store_transactions_test.py
@@ -1,12 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import text_type
 
 from iota import Iota, TransactionTrytes, TryteString, AsyncIota
 from iota.adapter import MockAdapter, async_return
@@ -19,7 +14,6 @@ class StoreTransactionsRequestFilterTestCase(BaseFilterTestCase):
   filter_type = StoreTransactionsCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(StoreTransactionsRequestFilterTestCase, self).setUp()
 
@@ -36,8 +30,8 @@ class StoreTransactionsRequestFilterTestCase(BaseFilterTestCase):
     request = {
       # Raw trytes are extracted to match the IRI's JSON protocol.
       'trytes': [
-        text_type(TransactionTrytes(self.trytes1)),
-        text_type(TransactionTrytes(self.trytes2)),
+        str(TransactionTrytes(self.trytes1)),
+        str(TransactionTrytes(self.trytes2)),
       ],
     }
 
@@ -67,8 +61,8 @@ class StoreTransactionsRequestFilterTestCase(BaseFilterTestCase):
       {
         # Raw trytes are extracted to match the IRI's JSON protocol.
         'trytes': [
-          text_type(TransactionTrytes(self.trytes1)),
-          text_type(TransactionTrytes(self.trytes2)),
+          str(TransactionTrytes(self.trytes1)),
+          str(TransactionTrytes(self.trytes2)),
         ],
       },
     )

--- a/test/commands/core/were_addresses_spent_from_test.py
+++ b/test/commands/core/were_addresses_spent_from_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -19,7 +15,6 @@ class WereAddressesSpentFromRequestFilterTestCase(BaseFilterTestCase):
         WereAddressesSpentFromCommand(MockAdapter()).get_request_filter
     skip_value_check = True
 
-    # noinspection SpellCheckingInspection
     def setUp(self):
         super(WereAddressesSpentFromRequestFilterTestCase, self).setUp()
 

--- a/test/commands/extended/__init__.py
+++ b/test/commands/extended/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/commands/extended/broadcast_and_store_test.py
+++ b/test/commands/extended/broadcast_and_store_test.py
@@ -1,10 +1,4 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
-
-from six import text_type
 
 from iota import Iota, AsyncIota, TransactionTrytes
 from iota.adapter import MockAdapter, async_return
@@ -12,7 +6,6 @@ from iota.commands.extended.broadcast_and_store import BroadcastAndStoreCommand
 from test import patch, MagicMock, async_test
 
 class BroadcastAndStoreCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(BroadcastAndStoreCommandTestCase, self).setUp()
 
@@ -76,8 +69,8 @@ class BroadcastAndStoreCommandTestCase(TestCase):
     """
     self.adapter.seed_response('broadcastTransactions', {
       'trytes': [
-        text_type(self.trytes1, 'ascii'),
-        text_type(self.trytes2, 'ascii'),
+        str(self.trytes1, 'ascii'),
+        str(self.trytes2, 'ascii'),
       ],
     })
 

--- a/test/commands/extended/broadcast_bundle_test.py
+++ b/test/commands/extended/broadcast_bundle_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -23,7 +19,6 @@ class BroadcastBundleRequestFilterTestCase(BaseFilterTestCase):
   def setUp(self):
     super(BroadcastBundleRequestFilterTestCase, self).setUp()
 
-    # noinspection SpellCheckingInspection
     self.transaction = (
       'TESTVALUE9DONTUSEINPRODUCTION99999KPZOTR'
       'VDB9GZDJGZSSDCBIX9QOK9PAV9RMDBGDXLDTIZTWQ'

--- a/test/commands/extended/find_transaction_objects_test.py
+++ b/test/commands/extended/find_transaction_objects_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 from iota import Iota, AsyncIota, MockAdapter, Transaction
@@ -11,7 +7,6 @@ from test import patch, MagicMock, mock, async_test
 
 
 class FindTransactionObjectsCommandTestCase(TestCase):
-    # noinspection SpellCheckingInspection
     def setUp(self):
         super(FindTransactionObjectsCommandTestCase, self).setUp()
 

--- a/test/commands/extended/get_account_data_test.py
+++ b/test/commands/extended/get_account_data_test.py
@@ -1,12 +1,6 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
-
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type
 
 from iota import Address, Bundle, Iota, AsyncIota, TransactionHash
 from iota.adapter import MockAdapter, async_return
@@ -22,7 +16,6 @@ class GetAccountDataRequestFilterTestCase(BaseFilterTestCase):
   filter_type = GetAccountDataCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetAccountDataRequestFilterTestCase, self).setUp()
 
@@ -54,7 +47,7 @@ class GetAccountDataRequestFilterTestCase(BaseFilterTestCase):
     filter_ = self._filter({
       # ``seed`` can be any value that is convertible into a
       # TryteString.
-      'seed': binary_type(self.seed),
+      'seed': bytes(self.seed),
 
       # These values must still be integers/bools, however.
       'start':            42,
@@ -336,7 +329,6 @@ class AsyncIter:
       yield item
 
 class GetAccountDataCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetAccountDataCommandTestCase, self).setUp()
 
@@ -422,7 +414,6 @@ class GetAccountDataCommandTestCase(TestCase):
     """
     Loading account data for an account.
     """
-    # noinspection PyUnusedLocal
     async def mock_iter_used_addresses(adapter, seed, start, security_level):
       """
       Mocks the ``iter_used_addresses`` function, so that we can

--- a/test/commands/extended/get_bundles_test.py
+++ b/test/commands/extended/get_bundles_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -22,7 +18,6 @@ class GetBundlesRequestFilterTestCase(BaseFilterTestCase):
     def setUp(self):
         super(GetBundlesRequestFilterTestCase, self).setUp()
 
-        # noinspection SpellCheckingInspection
         self.transactions = [
             (
                 'TESTVALUE9DONTUSEINPRODUCTION99999KPZOTR'

--- a/test/commands/extended/get_inputs_test.py
+++ b/test/commands/extended/get_inputs_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -21,7 +17,6 @@ class GetInputsRequestFilterTestCase(BaseFilterTestCase):
   filter_type = GetInputsCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetInputsRequestFilterTestCase, self).setUp()
 
@@ -403,7 +398,6 @@ class GetInputsRequestFilterTestCase(BaseFilterTestCase):
 
 
 class GetInputsCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetInputsCommandTestCase, self).setUp()
 
@@ -635,7 +629,6 @@ class GetInputsCommandTestCase(TestCase):
 
     # ``getInputs`` uses ``findTransactions`` and
     # ``wereAddressesSpentFrom`` to identify unused addresses.
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(
@@ -645,7 +638,6 @@ class GetInputsCommandTestCase(TestCase):
       ],
     })
 
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(
@@ -670,7 +662,6 @@ class GetInputsCommandTestCase(TestCase):
     # To keep the unit test nice and speedy, we will mock the address
     # generator.  We already have plenty of unit tests for that
     # functionality, so we can get away with mocking it here.
-    # noinspection PyUnusedLocal
     def mock_address_generator(ag, start, step=1):
       for addy in [self.addy0, self.addy1, self.addy2][start::step]:
         yield addy
@@ -714,7 +705,6 @@ class GetInputsCommandTestCase(TestCase):
     # To keep the unit test nice and speedy, we will mock the address
     # generator.  We already have plenty of unit tests for that
     # functionality, so we can get away with mocking it here.
-    # noinspection PyUnusedLocal
     def mock_address_generator(ag, start, step=1):
       for addy in [self.addy0, self.addy1, self.addy2][start::step]:
         yield addy
@@ -739,7 +729,6 @@ class GetInputsCommandTestCase(TestCase):
     # ``getInputs`` uses ``findTransactions`` and
     # ``wereAddressesSpentFrom`` to identify unused addresses.
     # addresses.
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(
@@ -749,7 +738,6 @@ class GetInputsCommandTestCase(TestCase):
       ],
     })
 
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(
@@ -775,7 +763,6 @@ class GetInputsCommandTestCase(TestCase):
     # To keep the unit test nice and speedy, we will mock the address
     # generator.  We already have plenty of unit tests for that
     # functionality, so we can get away with mocking it here.
-    # noinspection PyUnusedLocal
     def mock_address_generator(ag, start, step=1):
       for addy in [self.addy0, self.addy1, self.addy2][start::step]:
         yield addy
@@ -809,7 +796,6 @@ class GetInputsCommandTestCase(TestCase):
 
     # ``getInputs`` uses ``findTransactions`` and
     # ``wereAddressesSpentFrom`` to identify unused addresses.
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(
@@ -819,7 +805,6 @@ class GetInputsCommandTestCase(TestCase):
       ],
     })
 
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(
@@ -844,7 +829,6 @@ class GetInputsCommandTestCase(TestCase):
     # To keep the unit test nice and speedy, we will mock the address
     # generator.  We already have plenty of unit tests for that
     # functionality, so we can get away with mocking it here.
-    # noinspection PyUnusedLocal
     def mock_address_generator(ag, start, step=1):
       for addy in [self.addy0, self.addy1, self.addy2][start::step]:
         yield addy
@@ -883,7 +867,6 @@ class GetInputsCommandTestCase(TestCase):
 
     # ``getInputs`` uses ``findTransactions`` and
     # ``wereAddressesSpentFrom`` to identify unused addresses.
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(
@@ -908,7 +891,6 @@ class GetInputsCommandTestCase(TestCase):
     # To keep the unit test nice and speedy, we will mock the address
     # generator.  We already have plenty of unit tests for that
     # functionality, so we can get away with mocking it here.
-    # noinspection PyUnusedLocal
     def mock_address_generator(ag, start, step=1):
       # If ``start`` has the wrong value, return garbage to make the
       # test asplode.
@@ -945,7 +927,6 @@ class GetInputsCommandTestCase(TestCase):
     # To keep the unit test nice and speedy, we will mock the address
     # generator.  We already have plenty of unit tests for that
     # functionality, so we can get away with mocking it here.
-    # noinspection PyUnusedLocal
 
     def mock_address_generator(ag, start, step=1):
       # returning up to 3 addresses, depending on stop value
@@ -997,7 +978,6 @@ class GetInputsCommandTestCase(TestCase):
 
     # ``getInputs`` uses ``findTransactions`` and
     # ``wereAddressesSpentFrom`` to identify unused addresses.
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(
@@ -1050,7 +1030,6 @@ class GetInputsCommandTestCase(TestCase):
     })
     # ``getInputs`` uses ``findTransactions`` to identify unused
     # addresses.
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'hashes': [
         TransactionHash(

--- a/test/commands/extended/get_latest_inclusion_test.py
+++ b/test/commands/extended/get_latest_inclusion_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -19,7 +15,6 @@ class GetLatestInclusionRequestFilterTestCase(BaseFilterTestCase):
   filter_type = GetLatestInclusionCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetLatestInclusionRequestFilterTestCase, self).setUp()
 
@@ -176,7 +171,6 @@ class GetLatestInclusionRequestFilterTestCase(BaseFilterTestCase):
 
 
 class GetLatestInclusionCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetLatestInclusionCommandTestCase, self).setUp()
 

--- a/test/commands/extended/get_new_addresses_test.py
+++ b/test/commands/extended/get_new_addresses_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -20,7 +16,6 @@ class GetNewAddressesRequestFilterTestCase(BaseFilterTestCase):
   filter_type = GetNewAddressesCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetNewAddressesRequestFilterTestCase, self).setUp()
 
@@ -331,7 +326,6 @@ class GetNewAddressesRequestFilterTestCase(BaseFilterTestCase):
 
 
 class GetNewAddressesCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetNewAddressesCommandTestCase, self).setUp()
 
@@ -442,7 +436,6 @@ class GetNewAddressesCommandTestCase(TestCase):
         seed          = self.seed,
       )
 
-    # noinspection SpellCheckingInspection
     self.assertDictEqual(
       response,
 
@@ -541,7 +534,6 @@ class GetNewAddressesCommandTestCase(TestCase):
     self.adapter.seed_response('wereAddressesSpentFrom', {
       'states': [False],
     })
-    # noinspection SpellCheckingInspection
     self.adapter.seed_response('findTransactions', {
       'duration': 18,
       'hashes': [

--- a/test/commands/extended/get_transaction_objects_test.py
+++ b/test/commands/extended/get_transaction_objects_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 from iota import Iota, AsyncIota, MockAdapter, Transaction
@@ -11,7 +7,6 @@ from test import patch, MagicMock, mock, async_test
 
 
 class GetTransactionObjectsCommandTestCase(TestCase):
-    # noinspection SpellCheckingInspection
     def setUp(self):
         super(GetTransactionObjectsCommandTestCase, self).setUp()
 

--- a/test/commands/extended/get_transfers_test.py
+++ b/test/commands/extended/get_transfers_test.py
@@ -1,13 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type
-
 from iota import Address, Bundle, Iota, AsyncIota, Tag, Transaction, TryteString
 from iota.adapter import MockAdapter, async_return
 from iota.commands.extended.get_transfers import GetTransfersCommand, \
@@ -22,7 +16,6 @@ class GetTransfersRequestFilterTestCase(BaseFilterTestCase):
   filter_type = GetTransfersCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetTransfersRequestFilterTestCase, self).setUp()
 
@@ -316,7 +309,6 @@ class GetTransfersRequestFilterTestCase(BaseFilterTestCase):
     )
 
 
-# noinspection SpellCheckingInspection
 class GetTransfersCommandTestCase(TestCase):
   def setUp(self):
     super(GetTransfersCommandTestCase, self).setUp()
@@ -391,7 +383,6 @@ class GetTransfersCommandTestCase(TestCase):
     # :py:class:`iota.crypto.addresses.AddressGenerator` already has
     # its own test case, so this does not impact the stability of the
     # codebase.
-    # noinspection PyUnusedLocal
     def create_generator(ag, start, step=1):
       for addy in [self.addy1, self.addy2][start::step]:
         yield addy
@@ -493,7 +484,6 @@ class GetTransfersCommandTestCase(TestCase):
     # :py:class:`iota.crypto.addresses.AddressGenerator` already has
     # its own test case, so this does not impact the stability of the
     # codebase.
-    # noinspection PyUnusedLocal
     def create_generator(ag, start, step=1):
       for addy in [self.addy1][start::step]:
         yield addy
@@ -526,7 +516,6 @@ class GetTransfersCommandTestCase(TestCase):
     """
     Scanning the Tangle for all transfers, with start index.
     """
-    # noinspection PyUnusedLocal
     def create_generator(ag, start, step=1):
       # Inject an invalid value into the generator, to ensure it is
       # skipped.
@@ -622,7 +611,6 @@ class GetTransfersCommandTestCase(TestCase):
     """
     Scanning the Tangle for all transfers, with stop index.
     """
-    # noinspection PyUnusedLocal
     def create_generator(ag, start, step=1):
       # Inject an invalid value into the generator, to ensure it is
       # skipped.
@@ -701,7 +689,6 @@ class GetTransfersCommandTestCase(TestCase):
     """
     Fetching inclusion states with transactions.
     """
-    # noinspection PyUnusedLocal
     def create_generator(ag, start, step=1):
       for addy in [self.addy1][start::step]:
         yield addy
@@ -771,7 +758,7 @@ class GetTransfersCommandTestCase(TestCase):
 
       {
         'duration': 99,
-        'trytes':   [binary_type(transaction_trytes)],
+        'trytes':   [bytes(transaction_trytes)],
       },
     )
 

--- a/test/commands/extended/is_promotable_test.py
+++ b/test/commands/extended/is_promotable_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -20,7 +16,6 @@ class IsPromotableRequestFilterTestCase(BaseFilterTestCase):
     filter_type = IsPromotableCommand(MockAdapter()).get_request_filter
     skip_value_check = True
 
-    # noinspection SpellCheckingInspection
     def setUp(self):
         super(IsPromotableRequestFilterTestCase, self).setUp()
 

--- a/test/commands/extended/is_reattachable_test.py
+++ b/test/commands/extended/is_reattachable_test.py
@@ -1,13 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import text_type
-
 from iota import Address, Iota, AsyncIota
 from iota.adapter import MockAdapter, async_return
 from iota.commands.extended.is_reattachable import IsReattachableCommand
@@ -18,7 +12,6 @@ class IsReattachableRequestFilterTestCase(BaseFilterTestCase):
   filter_type = IsReattachableCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(IsReattachableRequestFilterTestCase, self).setUp()
 
@@ -54,8 +47,8 @@ class IsReattachableRequestFilterTestCase(BaseFilterTestCase):
       filter_.cleaned_data,
       {
         'addresses': [
-          text_type(Address(self.address_1)),
-          text_type(Address(self.address_2))
+          str(Address(self.address_1)),
+          str(Address(self.address_2))
         ],
       },
     )
@@ -129,12 +122,10 @@ class IsReattachableRequestFilterTestCase(BaseFilterTestCase):
     )
 
 
-# noinspection SpellCheckingInspection
 class IsReattachableResponseFilterTestCase(BaseFilterTestCase):
   filter_type = IsReattachableCommand(MockAdapter()).get_response_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(IsReattachableResponseFilterTestCase, self).setUp()
 

--- a/test/commands/extended/prepare_transfer_test.py
+++ b/test/commands/extended/prepare_transfer_test.py
@@ -1,12 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type, iterkeys
 
 from iota import Address, BadApiResponse, Iota, ProposedTransaction, Tag, \
   TryteString, Transaction, TransactionHash, AsyncIota
@@ -23,7 +18,6 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
   filter_type = PrepareTransferCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(PrepareTransferRequestFilterTestCase, self).setUp()
 
@@ -98,7 +92,7 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # Any TrytesCompatible value works here.
-      'changeAddress':  binary_type(self.trytes1),
+      'changeAddress':  bytes(self.trytes1),
       'seed':           bytearray(self.trytes2),
 
       # These have to be :py:class:`Address` instances, so that we can
@@ -370,7 +364,7 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
       {
         'inputs': [
           None,
-          binary_type(self.trytes1),
+          bytes(self.trytes1),
 
           # This is actually valid; I just added it to make sure the
           #   filter isn't cheating!
@@ -455,7 +449,6 @@ class PrepareTransferRequestFilterTestCase(BaseFilterTestCase):
     )
 
 
-# noinspection SpellCheckingInspection
 class PrepareTransferCommandTestCase(TestCase):
   """
   Generating validation data using the JS lib:
@@ -656,7 +649,7 @@ class PrepareTransferCommandTestCase(TestCase):
         ],
       )
 
-    self.assertEqual(set(iterkeys(response)), {'trytes'})
+    self.assertEqual(set(response.keys()), {'trytes'})
     self.assertEqual(len(response['trytes']), 2)
 
     # Note that the transactions are returned in reverse order.
@@ -731,7 +724,7 @@ class PrepareTransferCommandTestCase(TestCase):
       ],
     )
 
-    self.assertEqual(set(iterkeys(response)), {'trytes'})
+    self.assertEqual(set(response.keys()), {'trytes'})
     self.assertEqual(len(response['trytes']), 5)
 
     # Note that the transactions are returned in reverse order.
@@ -817,7 +810,7 @@ class PrepareTransferCommandTestCase(TestCase):
         ),
     )
 
-    self.assertEqual(set(iterkeys(response)), {'trytes'})
+    self.assertEqual(set(response.keys()), {'trytes'})
     self.assertEqual(len(response['trytes']), 4)
 
     # Note that the transactions are returned in reverse order.
@@ -955,7 +948,7 @@ class PrepareTransferCommandTestCase(TestCase):
           ],
         )
 
-    self.assertEqual(set(iterkeys(response)), {'trytes'})
+    self.assertEqual(set(response.keys()), {'trytes'})
     self.assertEqual(len(response['trytes']), 5)
 
     # Note that the transactions are returned in reverse order.
@@ -1051,7 +1044,7 @@ class PrepareTransferCommandTestCase(TestCase):
           ),
       )
 
-    self.assertEqual(set(iterkeys(response)), {'trytes'})
+    self.assertEqual(set(response.keys()), {'trytes'})
     self.assertEqual(len(response['trytes']), 4)
 
     # Note that the transactions are returned in reverse order.
@@ -1187,7 +1180,7 @@ class PrepareTransferCommandTestCase(TestCase):
           ],
         )
 
-    self.assertEqual(set(iterkeys(response)), {'trytes'})
+    self.assertEqual(set(response.keys()), {'trytes'})
     self.assertEqual(len(response['trytes']), 4)
 
     # Note that the transactions are returned in reverse order.
@@ -1243,7 +1236,7 @@ class PrepareTransferCommandTestCase(TestCase):
       ],
     )
 
-    self.assertEqual(set(iterkeys(response)), {'trytes'})
+    self.assertEqual(set(response.keys()), {'trytes'})
     self.assertEqual(len(response['trytes']), 1)
 
     self.assertEqual(
@@ -1303,7 +1296,7 @@ class PrepareTransferCommandTestCase(TestCase):
         ],
       )
 
-    self.assertEqual(set(iterkeys(response)), {'trytes'})
+    self.assertEqual(set(response.keys()), {'trytes'})
     self.assertEqual(len(response['trytes']), 3)
 
     # Note that the transactions are returned in reverse order.
@@ -1389,7 +1382,7 @@ class PrepareTransferCommandTestCase(TestCase):
             securityLevel=security_level
           )
 
-      self.assertEqual(set(iterkeys(response)), {'trytes'})
+      self.assertEqual(set(response.keys()), {'trytes'})
 
       EXPECTED_NUMBER_OF_TX = 2 + security_level   # signature requires as many transactions as security_level
       EXPECTED_CHANGE_VALUE = security_level * 11  # what has left depends on security_level
@@ -1479,7 +1472,7 @@ class PrepareTransferCommandTestCase(TestCase):
             securityLevel=security_level
           )
 
-      self.assertEqual(set(iterkeys(response)), {'trytes'})
+      self.assertEqual(set(response.keys()), {'trytes'})
 
       EXPECTED_NUMBER_OF_TX = 2 + security_level   # signature requires as many transactions as security_level
       EXPECTED_CHANGE_VALUE = security_level * 11  # what has left depends on security_level

--- a/test/commands/extended/promote_transaction_test.py
+++ b/test/commands/extended/promote_transaction_test.py
@@ -1,13 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type
-
 from iota import Bundle, Iota, TransactionHash, TransactionTrytes, \
   BadApiResponse, AsyncIota
 from iota.adapter import MockAdapter, async_return
@@ -21,7 +15,6 @@ class PromoteTransactionRequestFilterTestCase(BaseFilterTestCase):
   filter_type = PromoteTransactionCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(PromoteTransactionRequestFilterTestCase, self).setUp()
 
@@ -52,7 +45,7 @@ class PromoteTransactionRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # This can be any TrytesCompatible value.
-      'transaction': binary_type(self.trytes1),
+      'transaction': bytes(self.trytes1),
 
       # These values must still be ints, however.
       'depth':              100,

--- a/test/commands/extended/replay_bundle_test.py
+++ b/test/commands/extended/replay_bundle_test.py
@@ -1,13 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type
-
 from iota import Address, Bundle, BundleHash, Fragment, Iota, Nonce, Tag, \
   Transaction, TransactionHash, AsyncIota
 from iota.adapter import MockAdapter, async_return
@@ -21,7 +15,6 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
   filter_type = ReplayBundleCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(ReplayBundleRequestFilterTestCase, self).setUp()
 
@@ -52,7 +45,7 @@ class ReplayBundleRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # This can be any TrytesCompatible value.
-      'transaction': binary_type(self.trytes1),
+      'transaction': bytes(self.trytes1),
 
       # These values must still be ints, however.
       'depth':              100,
@@ -352,7 +345,6 @@ class ReplayBundleCommandTestCase(TestCase):
     """
     Successfully replaying a bundle.
     """
-    # noinspection SpellCheckingInspection
     bundle = Bundle([
       # "Spend" transaction, Part 1 of 1
       Transaction(

--- a/test/commands/extended/send_transfer_test.py
+++ b/test/commands/extended/send_transfer_test.py
@@ -1,13 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type
-
 from iota import Address, Bundle, Iota, ProposedTransaction, TransactionHash, \
   TransactionTrytes, TryteString, AsyncIota
 from iota.adapter import MockAdapter, async_return
@@ -23,7 +17,6 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
   filter_type = SendTransferCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(SendTransferRequestFilterTestCase, self).setUp()
 
@@ -106,12 +99,12 @@ class SendTransferRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # Any TrytesCompatible values will work here.
-      'changeAddress':  binary_type(self.trytes1),
+      'changeAddress':  bytes(self.trytes1),
       'seed':           bytearray(self.trytes2),
-      'reference':      binary_type(self.trytes1),
+      'reference':      bytes(self.trytes1),
 
       'inputs': [
-        binary_type(self.trytes3),
+        bytes(self.trytes3),
         bytearray(self.trytes4),
       ],
 
@@ -720,7 +713,6 @@ class SendTransferCommandTestCase(TestCase):
     """
     Sending a transfer successfully.
     """
-    # noinspection SpellCheckingInspection
     transaction1 =\
       TransactionTrytes(
         b'GYPRVHBEZOOFXSHQBLCYW9ICTCISLHDBNMMVYD9JJHQMPQCTIQAQTJNNNJ9IDXLRCC'

--- a/test/commands/extended/send_trytes_test.py
+++ b/test/commands/extended/send_trytes_test.py
@@ -1,13 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type, text_type
-
 from iota import Iota, TransactionTrytes, TryteString, TransactionHash, \
   AsyncIota
 from iota.adapter import MockAdapter, async_return
@@ -20,7 +14,6 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
   filter_type = SendTrytesCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(SendTrytesRequestFilterTestCase, self).setUp()
 
@@ -59,10 +52,10 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
     filter_ = self._filter({
       # This can accept any TrytesCompatible values.
       'trytes': [
-        binary_type(self.trytes1),
+        bytes(self.trytes1),
         bytearray(self.trytes2),
       ],
-      'reference': binary_type(self.trytes2),
+      'reference': bytes(self.trytes2),
 
       # These still have to be ints, however.
       'depth':              100,
@@ -348,7 +341,6 @@ class SendTrytesRequestFilterTestCase(BaseFilterTestCase):
 
 
 class SendTrytesCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(SendTrytesCommandTestCase, self).setUp()
 
@@ -421,14 +413,14 @@ class SendTrytesCommandTestCase(TestCase):
     Successful invocation of ``sendTrytes``.
     """
     self.adapter.seed_response('getTransactionsToApprove', {
-      'trunkTransaction':   text_type(self.transaction1, 'ascii'),
-      'branchTransaction':  text_type(self.transaction2, 'ascii'),
+      'trunkTransaction':   str(self.transaction1, 'ascii'),
+      'branchTransaction':  str(self.transaction2, 'ascii'),
     })
 
     self.adapter.seed_response('attachToTangle', {
       'trytes': [
-        text_type(self.trytes1, 'ascii'),
-        text_type(self.trytes2, 'ascii'),
+        str(self.trytes1, 'ascii'),
+        str(self.trytes2, 'ascii'),
       ],
     })
 

--- a/test/commands/extended/traverse_bundle_test.py
+++ b/test/commands/extended/traverse_bundle_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -22,7 +18,6 @@ class TraverseBundleRequestFilterTestCase(BaseFilterTestCase):
     def setUp(self):
         super(TraverseBundleRequestFilterTestCase, self).setUp()
 
-        # noinspection SpellCheckingInspection
         self.transaction = (
             'TESTVALUE9DONTUSEINPRODUCTION99999KPZOTR'
             'VDB9GZDJGZSSDCBIX9QOK9PAV9RMDBGDXLDTIZTWQ'
@@ -119,7 +114,6 @@ class TraverseBundleRequestFilterTestCase(BaseFilterTestCase):
         )
 
 
-# noinspection SpellCheckingInspection
 class TraverseBundleCommandTestCase(TestCase):
     def setUp(self):
         super(TraverseBundleCommandTestCase, self).setUp()

--- a/test/commands/extended/utils_test.py
+++ b/test/commands/extended/utils_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from unittest import TestCase
 from iota.commands.extended.utils import iter_used_addresses, \
     get_bundles_from_transaction_hashes

--- a/test/crypto/__init__.py
+++ b/test/crypto/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/crypto/addresses_test.py
+++ b/test/crypto/addresses_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import Address
@@ -12,7 +8,6 @@ from iota.crypto.types import Seed
 class AddressGeneratorTestCase(TestCase):
   maxDiff = None
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(AddressGeneratorTestCase, self).setUp()
 
@@ -34,7 +29,6 @@ class AddressGeneratorTestCase(TestCase):
     """
     ag = AddressGenerator(self.seed_1)
 
-    # noinspection SpellCheckingInspection
     self.assertListEqual(
       ag.get_addresses(start=0),
 
@@ -46,7 +40,6 @@ class AddressGeneratorTestCase(TestCase):
       ],
     )
 
-    # noinspection SpellCheckingInspection
     self.assertListEqual(
       ag.get_addresses(start=10),
 
@@ -64,7 +57,6 @@ class AddressGeneratorTestCase(TestCase):
     """
     ag = AddressGenerator(self.seed_2)
 
-    # noinspection SpellCheckingInspection
     self.assertListEqual(
       ag.get_addresses(start=0, count=3),
 
@@ -86,7 +78,6 @@ class AddressGeneratorTestCase(TestCase):
       ],
     )
 
-    # noinspection SpellCheckingInspection
     self.assertListEqual(
       ag.get_addresses(start=10, count=3),
 
@@ -149,7 +140,6 @@ class AddressGeneratorTestCase(TestCase):
     """
     ag = AddressGenerator(self.seed_1)
 
-    # noinspection SpellCheckingInspection
     self.assertListEqual(
       ag.get_addresses(start=1, count=2, step=-1),
 
@@ -174,7 +164,6 @@ class AddressGeneratorTestCase(TestCase):
 
     generator = ag.create_iterator()
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       next(generator),
 
@@ -184,7 +173,6 @@ class AddressGeneratorTestCase(TestCase):
       ),
     )
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       next(generator),
 
@@ -204,7 +192,6 @@ class AddressGeneratorTestCase(TestCase):
 
     generator = ag.create_iterator(start=1, step=2)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       next(generator),
 
@@ -214,7 +201,6 @@ class AddressGeneratorTestCase(TestCase):
       ),
     )
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       next(generator),
 
@@ -230,7 +216,6 @@ class AddressGeneratorTestCase(TestCase):
     """
     ag = AddressGenerator(self.seed_1, security_level=1)
 
-    # noinspection SpellCheckingInspection
     self.assertListEqual(
       ag.get_addresses(start=0, count=3),
 
@@ -258,7 +243,6 @@ class AddressGeneratorTestCase(TestCase):
     """
     ag = AddressGenerator(self.seed_1, security_level=3)
 
-    # noinspection SpellCheckingInspection
     self.assertListEqual(
       ag.get_addresses(start=0, count=3),
 
@@ -292,7 +276,6 @@ class AddressGeneratorTestCase(TestCase):
 
     generator = ag.create_iterator()
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       next(generator),
 
@@ -303,7 +286,6 @@ class AddressGeneratorTestCase(TestCase):
       ),
     )
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       next(generator),
 

--- a/test/crypto/kerl/__init__.py
+++ b/test/crypto/kerl/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/crypto/kerl/pykerl_test.py
+++ b/test/crypto/kerl/pykerl_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from csv import DictReader
 from os.path import dirname, join
 from random import randrange
@@ -27,7 +23,6 @@ class TestKerl(TestCase):
         )
 
     def test_correct_first(self):
-        # noinspection SpellCheckingInspection
         inp = (
           'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
           'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
@@ -42,7 +37,6 @@ class TestKerl(TestCase):
 
         trytes_out = trits_to_trytes(trits_out)
 
-        # noinspection SpellCheckingInspection
         self.assertEqual(
           trytes_out,
 
@@ -51,7 +45,6 @@ class TestKerl(TestCase):
         )
 
     def test_output_greater_243(self):
-        # noinspection SpellCheckingInspection
         inp = (
           '9MIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
           'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
@@ -66,7 +59,6 @@ class TestKerl(TestCase):
 
         trytes_out = trits_to_trytes(trits_out)
 
-        # noinspection SpellCheckingInspection
         self.assertEqual(
           trytes_out,
 
@@ -76,7 +68,6 @@ class TestKerl(TestCase):
         )
 
     def test_input_greater_243(self):
-        # noinspection SpellCheckingInspection
         inp = (
           'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
           'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
@@ -92,7 +83,6 @@ class TestKerl(TestCase):
 
         trytes_out = trits_to_trytes(trits_out)
 
-        # noinspection SpellCheckingInspection
         self.assertEqual(
           trytes_out,
 

--- a/test/crypto/pycurl_test.py
+++ b/test/crypto/pycurl_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import TryteString
@@ -25,7 +21,6 @@ class CurlTestCase(TestCase):
     """
     Typical use case.
     """
-    # noinspection SpellCheckingInspection
     input_ = (
       'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
       'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
@@ -40,7 +35,6 @@ class CurlTestCase(TestCase):
 
     trits_out = TryteString.from_trits(trits_out)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       trits_out,
 
@@ -52,7 +46,6 @@ class CurlTestCase(TestCase):
     """
     The input is longer than 1 hash.
     """
-    # noinspection SpellCheckingInspection
     input_ = (
       'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
       'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
@@ -68,7 +61,6 @@ class CurlTestCase(TestCase):
 
     trits_out = TryteString.from_trits(trits_out)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       trits_out,
 
@@ -80,7 +72,6 @@ class CurlTestCase(TestCase):
     """
     Specifying different values for the ``length`` argument.
     """
-    # noinspection SpellCheckingInspection
     input_ = (
       'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
       'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
@@ -97,7 +88,6 @@ class CurlTestCase(TestCase):
 
     trits_out = TryteString.from_trits(trits_out)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       trits_out,
 
@@ -109,7 +99,6 @@ class CurlTestCase(TestCase):
     """
     Passing an ``offset`` argument to :py:meth:`Curl.absorb`.
     """
-    # noinspection SpellCheckingInspection
     input_ = (
       'G9JYBOMPUXHYHKSNRNMMSSZCSHOFYOYNZRSZMAAYWDYEIMVVOGKPJB'
       'VBM9TDPULSFUNMTVXRKFIDOHUXXVYDLFSZYZTWQYTE9SPYYWYTXJYQ'
@@ -126,7 +115,6 @@ class CurlTestCase(TestCase):
 
     trits_out = TryteString.from_trits(trits_out)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       trits_out,
 
@@ -141,7 +129,6 @@ class CurlTestCase(TestCase):
     Example use case:
     https://github.com/iotaledger/iri/blob/v1.4.1.6/src/main/java/com/iota/iri/hash/ISS.java#L83
     """
-    # noinspection SpellCheckingInspection
     input_ = (
       'CDLFODMOGMQAWXDURDXTUAOO9BFESHYGZLBUWIIHPTLNZCUNHZAAXSUPUIBW'
       'IRLOVKCVWJSWEKRJQZUVRDZGZRNANUNCSGANCJWVHMZMVNJVUAZNFZKDAIVV'
@@ -169,7 +156,6 @@ class CurlTestCase(TestCase):
 
     trits_out = TryteString.from_trits(trits_out)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       trits_out,
 
@@ -181,7 +167,6 @@ class CurlTestCase(TestCase):
     """
     Squeezing more than 1 hash from the sponge.
     """
-    # noinspection SpellCheckingInspection
     input_ = (
       'EMIDYNHBWMBCXVDEFOFWINXTERALUKYYPPHKP9JJ'
       'FGJEIUY9MUDVNFZHMMWZUYUSWAIOWEVTHNWMHANBH'
@@ -196,7 +181,6 @@ class CurlTestCase(TestCase):
 
     trits_out = TryteString.from_trits(trits_out)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       trits_out,
 

--- a/test/crypto/signing_test.py
+++ b/test/crypto/signing_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 import warnings
 from unittest import TestCase
 
@@ -11,7 +7,6 @@ from iota.crypto.signing import KeyGenerator, SignatureFragmentGenerator
 from iota.crypto.types import PrivateKey
 
 
-# noinspection SpellCheckingInspection
 class KeyGeneratorTestCase(TestCase):
   """
   Generating validation data using the JS lib:
@@ -838,7 +833,6 @@ class KeyGeneratorTestCase(TestCase):
     )
 
 
-# noinspection SpellCheckingInspection
 class SignatureFragmentGeneratorTestCase(TestCase):
   """
   Generating values for this test case using the JS lib:

--- a/test/crypto/types_test.py
+++ b/test/crypto/types_test.py
@@ -1,12 +1,5 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 import warnings
 from unittest import TestCase
-
-from six import text_type
-
 from iota import Hash, TryteString
 from iota.crypto import SeedWarning
 from iota.crypto.types import Digest, PrivateKey, Seed
@@ -52,7 +45,7 @@ class SeedTestCase(TestCase):
       self.assertIs(catched_warnings[-1].category, SeedWarning)
       self.assertIn(
         "inappropriate length",
-        text_type(catched_warnings[-1].message),
+        str(catched_warnings[-1].message),
       )
 
       self.assertEqual(len(seed), Hash.LEN + 1)
@@ -86,7 +79,6 @@ class DigestTestCase(TestCase):
     with self.assertRaises(TypeError):
       random_digest = Digest.random()
 
-# noinspection SpellCheckingInspection
 class PrivateKeyTestCase(TestCase):
   """
   Generating validation data using the JS lib:

--- a/test/filters_test.py
+++ b/test/filters_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 import filters as f
 from filters.test import BaseFilterTestCase
 
@@ -48,7 +44,6 @@ class GeneratedAddressTestCase(BaseFilterTestCase):
     """
     Incoming value is not an :py:class:`Address` instance.
     """
-    # noinspection SpellCheckingInspection
     self.assertFilterErrors(
       # The only way to ensure ``key_index`` is set is to require that
       # the incoming value is an :py:class:`Address` instance.
@@ -121,7 +116,6 @@ class NodeUriTestCase(BaseFilterTestCase):
     )
 
 
-# noinspection SpellCheckingInspection
 class TrytesTestCase(BaseFilterTestCase):
   filter_type = Trytes
 
@@ -227,11 +221,9 @@ class TrytesTestCase(BaseFilterTestCase):
     )
 
 
-# noinspection SpellCheckingInspection
 class AddressNoChecksumTestCase(BaseFilterTestCase):
   filter_type = AddressNoChecksum
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(AddressNoChecksumTestCase, self).setUp()
 

--- a/test/local_pow_test.py
+++ b/test/local_pow_test.py
@@ -1,18 +1,9 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from iota import Iota, TryteString, TransactionHash, TransactionTrytes, \
     HttpAdapter, MockAdapter
 from iota.adapter.wrappers import RoutingWrapper
 from unittest import TestCase
 import sys
-from six import PY2
-
-if PY2:
-    from mock import MagicMock, patch
-else:
-    from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 # Load mocked package on import from pow pkg.
 # Therefore we can test without having to install it.

--- a/test/multisig/__init__.py
+++ b/test/multisig/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/multisig/commands/__init__.py
+++ b/test/multisig/commands/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/multisig/commands/create_multisig_address_test.py
+++ b/test/multisig/commands/create_multisig_address_test.py
@@ -1,13 +1,6 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
-
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type
-
 from iota import TryteString
 from iota.adapter import MockAdapter, async_return
 from iota.crypto.types import Digest
@@ -19,7 +12,6 @@ from test import patch, MagicMock, async_test
 
 
 class CreateMultisigAddressCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(CreateMultisigAddressCommandTestCase, self).setUp()
 
@@ -99,7 +91,6 @@ class CreateMultisigAddressCommandTestCase(TestCase):
     """
     result = await self.command(digests=[self.digest_1, self.digest_2])
 
-    # noinspection SpellCheckingInspection
     self.assertDictEqual(
       result,
 
@@ -120,7 +111,6 @@ class CreateMultisigAddressRequestFilterTestCase(BaseFilterTestCase):
   filter_type = CreateMultisigAddressCommand(MockAdapter()).get_request_filter
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(CreateMultisigAddressRequestFilterTestCase, self).setUp()
 
@@ -166,7 +156,7 @@ class CreateMultisigAddressRequestFilterTestCase(BaseFilterTestCase):
     filter_ = self._filter({
       # ``digests`` may contain any values that can be converted into
       # :py:class:`Digest` objects.
-      'digests': [binary_type(self.digest_1), TryteString(self.digest_2)],
+      'digests': [bytes(self.digest_1), TryteString(self.digest_2)],
     })
 
     self.assertFilterPasses(filter_)

--- a/test/multisig/commands/get_digests_test.py
+++ b/test/multisig/commands/get_digests_test.py
@@ -1,13 +1,7 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type
-
 from iota import Hash, TryteString
 from iota.adapter import MockAdapter, async_return
 from iota.crypto import FRAGMENT_LENGTH
@@ -20,7 +14,6 @@ from test import mock, patch, MagicMock, async_test
 
 
 class GetDigestsCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetDigestsCommandTestCase, self).setUp()
 
@@ -92,7 +85,6 @@ class GetDigestsCommandTestCase(TestCase):
         'iota.multisig.commands.get_private_keys.GetPrivateKeysCommand._execute',
         mock_get_private_keys
     ):
-      # noinspection PyUnresolvedReferences
       with mock.patch.object(self.key1, 'get_digest') as mock_get_digest_1: # type: mock.MagicMock
         mock_get_digest_1.return_value = self.digest1
 
@@ -121,11 +113,9 @@ class GetDigestsCommandTestCase(TestCase):
         'iota.multisig.commands.get_private_keys.GetPrivateKeysCommand._execute',
         mock_get_private_keys
     ):
-      # noinspection PyUnresolvedReferences
       with mock.patch.object(self.key1, 'get_digest') as mock_get_digest_1: # type: mock.MagicMock
         mock_get_digest_1.return_value = self.digest1
 
-        # noinspection PyUnresolvedReferences
         with mock.patch.object(self.key2, 'get_digest') as mock_get_digest_2: # type: mock.MagicMock
           mock_get_digest_2.return_value = self.digest2
 
@@ -149,7 +139,6 @@ class GetDigestsRequestFilterTestCase(BaseFilterTestCase):
     super(GetDigestsRequestFilterTestCase, self).setUp()
 
     # Define some tryte sequences that we can reuse between tests.
-    # noinspection SpellCheckingInspection
     self.seed = b'HELLOIOTA'
 
   def test_pass_happy_path(self):
@@ -195,7 +184,7 @@ class GetDigestsRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # ``seed`` can be any value that is convertible to TryteString.
-      'seed': binary_type(self.seed),
+      'seed': bytes(self.seed),
 
       # These values must be integers, however.
       'index':          100,

--- a/test/multisig/commands/get_private_keys_test.py
+++ b/test/multisig/commands/get_private_keys_test.py
@@ -1,13 +1,6 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
-
 import filters as f
 from filters.test import BaseFilterTestCase
-from six import binary_type
-
 from iota import TryteString
 from iota.adapter import MockAdapter, async_return
 from iota.crypto import FRAGMENT_LENGTH
@@ -20,7 +13,6 @@ from test import mock, patch, MagicMock, async_test
 
 
 class GetPrivateKeysCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(GetPrivateKeysCommandTestCase, self).setUp()
 
@@ -179,7 +171,7 @@ class GetPrivateKeysRequestFilterTestCase(BaseFilterTestCase):
     """
     filter_ = self._filter({
       # ``seed`` can be any value that is convertible to TryteString.
-      'seed': binary_type(self.seed),
+      'seed': bytes(self.seed),
 
       # These values must be integers, however.
       'index':          100,

--- a/test/multisig/commands/prepare_multisig_transfer_test.py
+++ b/test/multisig/commands/prepare_multisig_transfer_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 import filters as f
@@ -22,7 +18,6 @@ class PrepareMultisigTransferRequestFilterTestCase(BaseFilterTestCase):
   maxDiff = None
   skip_value_check = True
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(PrepareMultisigTransferRequestFilterTestCase, self).setUp()
 
@@ -482,7 +477,6 @@ class PrepareMultisigTransferRequestFilterTestCase(BaseFilterTestCase):
 
 
 class PrepareMultisigTransferCommandTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(PrepareMultisigTransferCommandTestCase, self).setUp()
 

--- a/test/multisig/crypto/__init__.py
+++ b/test/multisig/crypto/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/multisig/crypto/addresses_test.py
+++ b/test/multisig/crypto/addresses_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import Address
@@ -25,7 +21,6 @@ class MultisigAddressBuilderTestCase(TestCase):
      var addy = new Multisig(digests);
      console.log(addy.finalize());
   """
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(MultisigAddressBuilderTestCase, self).setUp()
 
@@ -71,7 +66,6 @@ class MultisigAddressBuilderTestCase(TestCase):
 
     self.assertIsInstance(addy, MultisigAddress)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       addy,
 
@@ -98,7 +92,6 @@ class MultisigAddressBuilderTestCase(TestCase):
 
     self.assertIsInstance(addy, MultisigAddress)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       addy,
 
@@ -142,7 +135,6 @@ class MultisigAddressBuilderTestCase(TestCase):
 
     self.assertIsInstance(addy, MultisigAddress)
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       addy,
 

--- a/test/multisig/transaction_test.py
+++ b/test/multisig/transaction_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import Address, ProposedTransaction
@@ -11,7 +7,6 @@ from iota.multisig.types import MultisigAddress
 
 
 class ProposedMultisigBundleTestCase(TestCase):
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(ProposedMultisigBundleTestCase, self).setUp()
 
@@ -57,7 +52,6 @@ class ProposedMultisigBundleTestCase(TestCase):
     """
     Adding a multisig input to a bundle.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(
       ProposedTransaction(
         address = Address(self.trytes_1),
@@ -126,7 +120,6 @@ class ProposedMultisigBundleTestCase(TestCase):
     This is not currently supported.
     """
     with self.assertRaises(ValueError):
-      # noinspection SpellCheckingInspection
       self.bundle.add_inputs([
         MultisigAddress(
           trytes  = self.trytes_1,
@@ -147,7 +140,6 @@ class ProposedMultisigBundleTestCase(TestCase):
     This is not currently supported.
     """
     with self.assertRaises(TypeError):
-      # noinspection SpellCheckingInspection,PyTypeChecker
       self.bundle.add_inputs([
         Address(
           trytes    = self.trytes_1,

--- a/test/transaction/__init__.py
+++ b/test/transaction/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals

--- a/test/transaction/base_test.py
+++ b/test/transaction/base_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import Address, Bundle, BundleHash, Fragment, Hash, Nonce, Tag, \
@@ -12,7 +8,6 @@ class BundleTestCase(TestCase):
   def setUp(self):
     super(BundleTestCase, self).setUp()
 
-    # noinspection SpellCheckingInspection
     self.bundle = Bundle([
       # This transaction does not have a message.
       Transaction(
@@ -303,7 +298,6 @@ class BundleTestCase(TestCase):
 
     self.assertEqual(messages[0], 'Hello, world!')
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       messages[1],
 
@@ -386,7 +380,6 @@ class TransactionTestCase(TestCase):
   - ``lib/utils/utils.js:transactionTrytes``:  Convert an object back
     into a tryte sequence.
   """
-  # noinspection SpellCheckingInspection
   def test_from_tryte_string(self):
     """
     Initializing a Transaction object from a TryteString.
@@ -553,7 +546,6 @@ class TransactionTestCase(TestCase):
     Initializing a Transaction object from a TryteString, with a
     pre-computed hash.
     """
-    # noinspection SpellCheckingInspection
     txn_hash =\
       TransactionHash(
         b'TESTVALUE9DONTUSEINPRODUCTION99999VALCXC'
@@ -564,7 +556,6 @@ class TransactionTestCase(TestCase):
 
     self.assertEqual(txn.hash, txn_hash)
 
-  # noinspection SpellCheckingInspection
   def test_as_tryte_string(self):
     """
     Converting a Transaction into a TryteString.

--- a/test/transaction/creation_test.py
+++ b/test/transaction/creation_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import Address, Fragment, ProposedBundle, ProposedTransaction, Tag, \
@@ -18,7 +14,6 @@ class ProposedBundleTestCase(TestCase):
     # We will use a seed to generate addresses and private keys, to
     # ensure a realistic scenario (and because the alternative is to
     # inject mocks all over the place!).
-    # noinspection SpellCheckingInspection
     self.seed =\
       Seed(
         b'TESTVALUE9DONTUSEINPRODUCTION99999RLC9CS'
@@ -28,7 +23,6 @@ class ProposedBundleTestCase(TestCase):
     # To speed things up a little bit, though, we can pre-generate a
     # few addresses to use as inputs.
 
-    # noinspection SpellCheckingInspection
     self.input_0_bal_eq_42 =\
       Address(
         balance         = 42,
@@ -40,7 +34,6 @@ class ProposedBundleTestCase(TestCase):
           b'9KKMHXFMIXHLKQQAVTTNPRCZENGLIPALHKLNKTXCU',
       )
 
-    # noinspection SpellCheckingInspection
     self.input_1_bal_eq_40 =\
       Address(
         balance         = 40,
@@ -52,7 +45,6 @@ class ProposedBundleTestCase(TestCase):
           b'DSMZXPL9KXREBBYHJGRBCYVGPJQEHEDPXLBDJNQNX',
       )
 
-    # noinspection SpellCheckingInspection
     self.input_2_bal_eq_2 =\
       Address(
         balance         = 2,
@@ -64,7 +56,6 @@ class ProposedBundleTestCase(TestCase):
           b'TRRJPNTSQRZTASRBTQCRFAIDOGTWSHIDGOUUULQIG',
       )
 
-    # noinspection SpellCheckingInspection
     self.input_3_bal_eq_100 =\
       Address(
         balance         = 100,
@@ -76,7 +67,6 @@ class ProposedBundleTestCase(TestCase):
           b'YLOAZNKJR9VDYSONVAJRIPVWCOZKFMEKUSWHPSDDZ',
       )
 
-    # noinspection SpellCheckingInspection
     self.input_4_bal_eq_42_sl_2 =\
       Address(
         balance         = 42,
@@ -88,7 +78,6 @@ class ProposedBundleTestCase(TestCase):
           b'EMMJ9BCDVVHJJLSTQW9JEJXUUX9JNFGALBNASRDUD',
       )
 
-    # noinspection SpellCheckingInspection
     self.input_5_bal_eq_42_sl_3 =\
       Address(
         balance         = 42,
@@ -107,7 +96,6 @@ class ProposedBundleTestCase(TestCase):
     Adding a transaction to a bundle, with a message short enough to
     fit inside a single transaction.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -128,7 +116,6 @@ class ProposedBundleTestCase(TestCase):
     Adding a transaction to a bundle, with a message so long that it
     has to be split into multiple transactions.
     """
-    # noinspection SpellCheckingInspection
     address = Address(
       b'TESTVALUE9DONTUSEINPRODUCTION99999N9GIUF'
       b'HCFIUGLBSCKELC9IYENFPHCEWHIDCHCGGEH9OFZBN'
@@ -203,7 +190,6 @@ They both licked their dry lips.
     Attempting to add a transaction to a bundle that is already
     finalized.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -237,7 +223,6 @@ They both licked their dry lips.
     """
     Adding inputs to cover the exact amount of the bundle spend.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -248,7 +233,6 @@ They both licked their dry lips.
         value = 29,
     ))
 
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -266,7 +250,6 @@ They both licked their dry lips.
 
     # Just to be tricky, add an unnecessary change address, just to
     # make sure the bundle ignores it.
-    # noinspection SpellCheckingInspection
     self.bundle.send_unspent_inputs_to(
       Address(
         b'TESTVALUE9DONTUSEINPRODUCTION99999FDCDFD'
@@ -290,7 +273,6 @@ They both licked their dry lips.
     """
     tag = Tag(b'CHANGE9TXN')
 
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -301,7 +283,6 @@ They both licked their dry lips.
         value = 29,
     ))
 
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -315,7 +296,6 @@ They both licked their dry lips.
 
     self.bundle.add_inputs([self.input_3_bal_eq_100])
 
-    # noinspection SpellCheckingInspection
     change_address =\
       Address(
         b'TESTVALUE9DONTUSEINPRODUCTION99999KAFGVC'
@@ -339,7 +319,6 @@ They both licked their dry lips.
     Each input's security level determines the number of transactions
     we will need in order to store the entire signature.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(
       ProposedTransaction(
         address =
@@ -369,7 +348,6 @@ They both licked their dry lips.
     Attempting to add inputs to a bundle that is already finalized.
     """
     # Add 1 transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(
       ProposedTransaction(
         address =
@@ -396,7 +374,6 @@ They both licked their dry lips.
     finalized.
     """
     # Add 1 transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -417,7 +394,6 @@ They both licked their dry lips.
     Attempting to finalize a bundle that is already finalized.
     """
     # Add 1 transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -444,7 +420,6 @@ They both licked their dry lips.
     """
     Attempting to finalize a bundle with unspent inputs.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -469,7 +444,6 @@ They both licked their dry lips.
     """
     Attempting to finalize a bundle with insufficient inputs.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -497,7 +471,6 @@ They both licked their dry lips.
     References:
       - https://github.com/iotaledger/iota.py/issues/84
     """
-    # noinspection SpellCheckingInspection
     bundle =\
       ProposedBundle([
         ProposedTransaction(
@@ -517,15 +490,12 @@ They both licked their dry lips.
 
     # The resulting bundle hash is insecure (contains a [1, 1, 1]), so
     # the legacy tag is manipulated until a secure hash is generated.
-    # noinspection SpellCheckingInspection
     self.assertEqual(bundle[0].legacy_tag, Tag('ZTDIDNQDJZGUQKOWJ9JZRCKOVGP'))
 
     # The proper tag is left alone, however.
-    # noinspection SpellCheckingInspection
     self.assertEqual(bundle[0].tag, Tag('PPDIDNQDJZGUQKOWJ9JZRCKOVGP'))
 
     # The bundle hash takes the modified legacy tag into account.
-    # noinspection SpellCheckingInspection
     self.assertEqual(
       bundle.hash,
 
@@ -539,7 +509,6 @@ They both licked their dry lips.
     """
     Signing inputs in a finalized bundle, using a key generator.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -590,7 +559,6 @@ They both licked their dry lips.
     You may include inputs with different security levels in the same
     bundle.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(
       ProposedTransaction(
         address =
@@ -642,7 +610,6 @@ They both licked their dry lips.
     yet.
     """
     # Add a transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -666,7 +633,6 @@ They both licked their dry lips.
     Signing an input at the specified index, only 1 fragment needed.
     """
     # Add a transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -715,7 +681,6 @@ They both licked their dry lips.
     Signing an input at the specified index, multiple fragments needed.
     """
     # Add a transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -763,7 +728,6 @@ They both licked their dry lips.
     Cannot sign inputs because the bundle isn't finalized yet.
     """
     # Add a transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -790,7 +754,6 @@ They both licked their dry lips.
     The specified index doesn't exist in the bundle.
     """
     # Add a transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -815,7 +778,6 @@ They both licked their dry lips.
     The specified index references a transaction that is not an input.
     """
     # Add a transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(
@@ -841,7 +803,6 @@ They both licked their dry lips.
     Attempting to sign an input that is already signed.
     """
     # Add a transaction so that we can finalize the bundle.
-    # noinspection SpellCheckingInspection
     self.bundle.add_transaction(ProposedTransaction(
       address =
         Address(

--- a/test/transaction/types_test.py
+++ b/test/transaction/types_test.py
@@ -1,11 +1,4 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
-
-from six import binary_type
-
 from iota import TransactionHash, BundleHash, Fragment, TransactionTrytes, \
   Nonce
 
@@ -15,15 +8,13 @@ class TransactionHashTestCase(TestCase):
     """
     Transaction hashes are automatically padded to 81 trytes.
     """
-    # noinspection SpellCheckingInspection
     txn = TransactionHash(
       b'JVMTDGDPDFYHMZPMWEKKANBQSLSDTIIHAYQUMZOK'
       b'HXXXGJHJDQPOMDOMNRDKYCZRUFZROZDADTHZC'
     )
 
-    # noinspection SpellCheckingInspection
     self.assertEqual(
-      binary_type(txn),
+      bytes(txn),
 
       # Note the extra 9's added to the end.
       b'JVMTDGDPDFYHMZPMWEKKANBQSLSDTIIHAYQUMZOK'
@@ -35,7 +26,6 @@ class TransactionHashTestCase(TestCase):
     Attempting to create a transaction hash longer than 81 trytes.
     """
     with self.assertRaises(ValueError):
-      # noinspection SpellCheckingInspection
       TransactionHash(
         b'JVMTDGDPDFYHMZPMWEKKANBQSLSDTIIHAYQUMZOK'
         b'HXXXGJHJDQPOMDOMNRDKYCZRUFZROZDADTHZC99999'

--- a/test/transaction/utils_test.py
+++ b/test/transaction/utils_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import convert_value_to_standard_unit
@@ -48,7 +44,6 @@ class ConvertValueToStandardUnitTestCase(TestCase):
     Attempting to convert invalid type: list.
     """
     with self.assertRaises(ValueError):
-      # noinspection PyTypeChecker
       convert_value_to_standard_unit(['3.141592', 'Pi'], 'Gi')
 
   def test_convert_type_float(self):
@@ -56,7 +51,6 @@ class ConvertValueToStandardUnitTestCase(TestCase):
     Attempting to convert invalid type: float.
     """
     with self.assertRaises(ValueError):
-      # noinspection PyTypeChecker
       convert_value_to_standard_unit(3.141592, 'Pi')
 
   def test_convert_value_no_space(self):

--- a/test/transaction/validator_test.py
+++ b/test/transaction/validator_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import Address, Bundle, BundleHash, BundleValidator, TransactionTrytes
@@ -110,7 +106,6 @@ class BundleValidatorTestCase(TestCase):
   consider the bundle to be valid.
   """
 
-  # noinspection SpellCheckingInspection
   def setUp(self):
     super(BundleValidatorTestCase, self).setUp()
 
@@ -205,7 +200,6 @@ class BundleValidatorTestCase(TestCase):
     """
     One of the transactions has an invalid ``bundle_hash`` value.
     """
-    # noinspection SpellCheckingInspection
     self.bundle.transactions[3].bundle_hash =\
       BundleHash(
         b'NFDPEEZCWVYLKZGSLCQNOFUSENIXRHWWTZFBXMPS'
@@ -294,7 +288,6 @@ class BundleValidatorTestCase(TestCase):
     One of the signature fragments for an input is associated with the
     wrong address.
     """
-    # noinspection SpellCheckingInspection
     self.bundle[5].address =\
       Address(
         b'QHEDFWZULBZFEOMNLRNIDQKDNNIELAOXOVMYEI9P'
@@ -426,7 +419,6 @@ class BundleValidatorMultisigTestCase(TestCase):
     super(BundleValidatorMultisigTestCase, self).setUp()
 
     # This is the result from ``examples/multisig.py``.
-    # noinspection SpellCheckingInspection
     self.bundle =\
       Bundle.from_tryte_strings([
         # Spend transaction.

--- a/test/trits_test.py
+++ b/test/trits_test.py
@@ -1,7 +1,3 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 
 from iota import trits_from_int

--- a/test/types_test.py
+++ b/test/types_test.py
@@ -1,24 +1,17 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-  unicode_literals
-
 from unittest import TestCase
 from warnings import catch_warnings, simplefilter as simple_filter
-
-from six import binary_type, text_type
 
 from iota import Address, AddressChecksum, AsciiTrytesCodec, Hash, Tag, \
   TryteString, TrytesDecodeError
 
 
-# noinspection SpellCheckingInspection
 class TryteStringTestCase(TestCase):
   def test_ascii_bytes(self):
     """
     Getting an ASCII representation of a TryteString, as bytes.
     """
     self.assertEqual(
-      binary_type(TryteString(b'HELLOIOTA')),
+      bytes(TryteString(b'HELLOIOTA')),
       b'HELLOIOTA',
     )
 
@@ -28,7 +21,7 @@ class TryteStringTestCase(TestCase):
     string.
     """
     self.assertEqual(
-      text_type(TryteString(b'HELLOIOTA')),
+      str(TryteString(b'HELLOIOTA')),
       'HELLOIOTA',
     )
 
@@ -74,7 +67,6 @@ class TryteStringTestCase(TestCase):
     self.assertFalse(trytes3 == bytearray(b'RBTC9D9DCDQAEASBYBCCKBFA'))
     self.assertTrue(trytes3 != bytearray(b'RBTC9D9DCDQAEASBYBCCKBFA'))
 
-  # noinspection PyTypeChecker
   def test_comparison_error_wrong_type(self):
     """
     Attempting to compare a TryteString with something that is not a
@@ -85,7 +77,6 @@ class TryteStringTestCase(TestCase):
     with self.assertRaises(TypeError):
       # TryteString is not a numeric type, so comparing against a
       # numeric value doesn't make any sense.
-      # noinspection PyStatementEffect
       trytes == 42
 
     # Identity comparison still works though.
@@ -141,26 +132,22 @@ class TryteStringTestCase(TestCase):
     with self.assertRaises(TypeError):
       # TryteString is not a numeric type, so this makes about as much
       # sense as ``16 in b'Hello, world!'``.
-      # noinspection PyStatementEffect,PyTypeChecker
       16 in trytes
 
     with self.assertRaises(TypeError):
       # This is too ambiguous.  Is this a list of trit values that can
       # appar anywhere in the tryte sequence, or does it have to match
       # a tryte exactly?
-      # noinspection PyStatementEffect,PyTypeChecker
       [0, 1, 1, 0, -1, 0] in trytes
 
     with self.assertRaises(TypeError):
       # This makes more sense than the previous example, but for
       # consistency, we will not allow checking for trytes inside
       # of a TryteString.
-      # noinspection PyStatementEffect,PyTypeChecker
       [[0, 0, 0], [1, 1, 0]] in trytes
 
     with self.assertRaises(TypeError):
       # Did I miss something? When did we get to DisneyLand?
-      # noinspection PyStatementEffect,PyTypeChecker
       None in trytes
 
   def test_concatenation(self):
@@ -172,21 +159,21 @@ class TryteStringTestCase(TestCase):
 
     concat = trytes1 + trytes2
     self.assertIsInstance(concat, TryteString)
-    self.assertEqual(binary_type(concat), b'RBTC9D9DCDQAEASBYBCCKBFA')
+    self.assertEqual(bytes(concat), b'RBTC9D9DCDQAEASBYBCCKBFA')
 
     # You can also concatenate a TryteString with any TrytesCompatible.
     self.assertEqual(
-      binary_type(trytes1 + b'EASBYBCCKBFA'),
+      bytes(trytes1 + b'EASBYBCCKBFA'),
       b'RBTC9D9DCDQAEASBYBCCKBFA',
     )
 
     self.assertEqual(
-      binary_type(trytes1 + 'EASBYBCCKBFA'),
+      bytes(trytes1 + 'EASBYBCCKBFA'),
       b'RBTC9D9DCDQAEASBYBCCKBFA',
     )
 
     self.assertEqual(
-      binary_type(trytes1 + bytearray(b'EASBYBCCKBFA')),
+      bytes(trytes1 + bytearray(b'EASBYBCCKBFA')),
       b'RBTC9D9DCDQAEASBYBCCKBFA',
     )
 
@@ -220,7 +207,6 @@ class TryteStringTestCase(TestCase):
     self.assertEqual(ts[4:-4:4], TryteString(b'9CEY'))
 
     with self.assertRaises(IndexError):
-      # noinspection PyStatementEffect
       ts[42]
 
     # To match the behavior of built-in types, TryteString will allow
@@ -329,7 +315,7 @@ class TryteStringTestCase(TestCase):
     addy = Address(TryteString(tag))
 
     self.assertEqual(
-      binary_type(addy),
+      bytes(addy),
 
       b'RBTC9D9DCDQAEASBYBCCKBFA9999999999999999'
       b'99999999999999999999999999999999999999999',
@@ -348,7 +334,7 @@ class TryteStringTestCase(TestCase):
     )
 
     self.assertEqual(
-      binary_type(trytes),
+      bytes(trytes),
 
       # Note the additional Tryte([-1, -1, -1]) values appended to the
       #   end of the sequence (represented in ASCII as '9').
@@ -367,7 +353,7 @@ class TryteStringTestCase(TestCase):
     self.assertFalse(trytes1 is trytes2)
     self.assertFalse(trytes1 == trytes2)
 
-    self.assertEqual(binary_type(trytes2), b'RBTC9D9DCDQAEASBYBCCKBFA999')
+    self.assertEqual(bytes(trytes2), b'RBTC9D9DCDQAEASBYBCCKBFA999')
 
   def test_init_error_invalid_characters(self):
     """
@@ -377,7 +363,6 @@ class TryteStringTestCase(TestCase):
     with self.assertRaises(ValueError):
       TryteString(b'not valid')
 
-  # noinspection PyTypeChecker
   def test_init_error_int(self):
     """
     Attempting to reset a TryteString from an int.
@@ -773,7 +758,7 @@ class TryteStringTestCase(TestCase):
     Converting a sequence of bytes into a TryteString.
     """
     self.assertEqual(
-      binary_type(TryteString.from_bytes(b'Hello, IOTA!')),
+      bytes(TryteString.from_bytes(b'Hello, IOTA!')),
       b'RBTC9D9DCDQAEASBYBCCKBFA',
     )
 
@@ -782,7 +767,7 @@ class TryteStringTestCase(TestCase):
     Converting a Unicode string into a TryteString.
     """
     self.assertEqual(
-      binary_type(TryteString.from_unicode('你好，世界！')),
+      bytes(TryteString.from_unicode('你好，世界！')),
       b'LH9GYEMHCF9GWHZFEELHVFOEOHNEEEWHZFUD',
     )
 
@@ -804,7 +789,7 @@ class TryteStringTestCase(TestCase):
     )
 
     self.assertEqual(
-      binary_type(trytes),
+      bytes(trytes),
       b'LH9GYEMHCF9GWHZFEELHVFOEOHNEEEWHZFUD',
     )
 
@@ -840,7 +825,7 @@ class TryteStringTestCase(TestCase):
     ]
 
     self.assertEqual(
-      binary_type(TryteString.from_trytes(trytes)),
+      bytes(TryteString.from_trytes(trytes)),
       b'RBTC9D9DCDQAEASBYBCCKBFA',
     )
 
@@ -876,7 +861,7 @@ class TryteStringTestCase(TestCase):
     ]
 
     self.assertEqual(
-      binary_type(TryteString.from_trits(trits)),
+      bytes(TryteString.from_trits(trits)),
       b'RBTC9D9DCDQAEASBYBCCKBFA',
     )
 
@@ -893,7 +878,7 @@ class TryteStringTestCase(TestCase):
     ]
 
     self.assertEqual(
-      binary_type(TryteString.from_trits(trits)),
+      bytes(TryteString.from_trits(trits)),
       b'RBTC',
     )
 
@@ -906,7 +891,6 @@ class HashTestCase(TestCase):
     self.assertEqual(len(rand), Hash.LEN)
 
 
-# noinspection SpellCheckingInspection
 class AddressTestCase(TestCase):
   def test_init_automatic_pad(self):
     """
@@ -918,7 +902,7 @@ class AddressTestCase(TestCase):
     )
 
     self.assertEqual(
-      binary_type(addy),
+      bytes(addy),
 
       # Note the extra 9's added to the end.
       b'JVMTDGDPDFYHMZPMWEKKANBQSLSDTIIHAYQUMZOK'
@@ -928,7 +912,7 @@ class AddressTestCase(TestCase):
     # This attribute will make more sense once we start working with
     # address checksums.
     self.assertEqual(
-      binary_type(addy.address),
+      bytes(addy.address),
 
       b'JVMTDGDPDFYHMZPMWEKKANBQSLSDTIIHAYQUMZOK'
       b'HXXXGJHJDQPOMDOMNRDKYCZRUFZROZDADTHZC9999',
@@ -960,21 +944,21 @@ class AddressTestCase(TestCase):
     )
 
     self.assertEqual(
-      binary_type(addy),
+      bytes(addy),
 
       b'RVORZ9SIIP9RCYMREUIXXVPQIPHVCNPQ9HZWYKFWYWZRE'
       b'9JQKG9REPKIASHUUECPSQO9JT9XNMVKWYGVAFOXM9MUBX',
     )
 
     self.assertEqual(
-      binary_type(addy.address),
+      bytes(addy.address),
 
       b'RVORZ9SIIP9RCYMREUIXXVPQIPHVCNPQ9HZWYKFWYWZRE'
       b'9JQKG9REPKIASHUUECPSQO9JT9XNMVKWYGVA',
     )
 
     self.assertEqual(
-      binary_type(addy.checksum),
+      bytes(addy.checksum),
       b'FOXM9MUBX',
     )
 
@@ -1003,7 +987,7 @@ class AddressTestCase(TestCase):
     self.assertTrue(addy.is_checksum_valid())
 
     self.assertEqual(
-      binary_type(addy.with_valid_checksum()),
+      bytes(addy.with_valid_checksum()),
 
       b'RVORZ9SIIP9RCYMREUIXXVPQIPHVCNPQ9HZWYKFWYWZRE'
       b'9JQKG9REPKIASHUUECPSQO9JT9XNMVKWYGVAITCOXAQSD',
@@ -1025,7 +1009,7 @@ class AddressTestCase(TestCase):
     self.assertFalse(addy.is_checksum_valid())
 
     self.assertEqual(
-      binary_type(addy.with_valid_checksum()),
+      bytes(addy.with_valid_checksum()),
 
       b'IGKUOZGEFNSVJXETLIBKRSUZAWMYSVDPMHGQPCETEFNZP'
       b'XSJLZMBLAWDRLUBWPIPKFNEPADIWMXMYYRKQXYYNAFRMA',
@@ -1045,7 +1029,7 @@ class AddressTestCase(TestCase):
     self.assertFalse(addy.is_checksum_valid())
 
     self.assertEqual(
-      binary_type(addy.with_valid_checksum()),
+      bytes(addy.with_valid_checksum()),
 
       b'ZKIUDZXQYQAWSHPKSAATJXPAQZPGYCDCQDRSMWWCGQJNI'
       b'PCOORMDRNREDUDKBMUYENYTFVUNEWDBAKXMVJJJGBARPB',
@@ -1153,13 +1137,12 @@ class AddressTestCase(TestCase):
     addy = Address.random()
     self.assertEqual(len(addy), Address.LEN)
 
-# noinspection SpellCheckingInspection
 class AddressChecksumTestCase(TestCase):
   def test_init_happy_path(self):
     """
     Creating a valid address checksum.
     """
-    self.assertEqual(binary_type(AddressChecksum(b'FOXM9MUBX')), b'FOXM9MUBX')
+    self.assertEqual(bytes(AddressChecksum(b'FOXM9MUBX')), b'FOXM9MUBX')
 
   def test_init_error_too_short(self):
     """
@@ -1185,7 +1168,6 @@ class AddressChecksumTestCase(TestCase):
     self.assertEqual(len(checksum), AddressChecksum.LEN)
 
 
-# noinspection SpellCheckingInspection
 class TagTestCase(TestCase):
   def test_init_automatic_pad(self):
     """
@@ -1193,7 +1175,7 @@ class TagTestCase(TestCase):
     """
     tag = Tag(b'COLOREDCOINS')
 
-    self.assertEqual(binary_type(tag), b'COLOREDCOINS999999999999999')
+    self.assertEqual(bytes(tag), b'COLOREDCOINS999999999999999')
 
   def test_init_error_too_long(self):
     """


### PR DESCRIPTION
## Related issue: #308 #301 
## Description
With #301 Python 2 (and Python 3.5) is no longer supported in PyOTA.

This PR removes glue code that made it possible to run the same code on both python versions, as it is no longer needed.

Changes:
 - Remove imports from `six` package, and `six` is no longer a pyota dependency.
 - Remove imports from `__future__` package. (was needed for string handling, absolute imports, different division syntax and print function)
 - Add some PY3 syntax where necessary. (metaclasses, `random.choices`, etc.)