### PR TITLE
Fix typo in docs example code

### DIFF
--- a/docs/transfers.rst
+++ b/docs/transfers.rst
@@ -200,7 +200,7 @@ with :py:class:`ProposedTransaction`.
     ]
 
     imaginary_bundle = api.send_transfer(
-        transfers=transactions
+        transfers=fictional_transactions
     )['bundle']
 
 As all API methods in PyOTA, :py:meth:`~Iota.send_transfer` also returns


### PR DESCRIPTION
# Description of change

Fix a typo in the example code for `Transfers` section.

## Type of change

- Documentation Fix

## Change checklist
- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/` directory and/or `docstring`s in source code)
- [x] I have followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) Style Guide in my code.
- [x] New and existing unit tests pass locally with my changes
