### PR TITLE
Introduce `is_confirmed` extended api call

### DIFF
--- a/docs/extended_api.rst
+++ b/docs/extended_api.rst
@@ -67,6 +67,11 @@ tasks such as sending and receiving transfers.
 .. automethod:: Iota.get_transfers
 .. automethod:: AsyncIota.get_transfers
 
+``is_confirmed``
+-----------------
+.. automethod:: Iota.is_confirmed
+.. automethod:: AsyncIota.is_confirmed
+
 ``is_promotable``
 -----------------
 .. automethod:: Iota.is_promotable

--- a/iota/api.py
+++ b/iota/api.py
@@ -407,6 +407,9 @@ class StrictIota(AsyncStrictIota):
                 )
         )
 
+    # Add an alias for this call, more descriptive
+    is_confirmed = get_inclusion_states
+
     def get_missing_transactions(self) -> dict:
         """
         Returns all transaction hashes that a node is currently requesting

--- a/iota/api_async.py
+++ b/iota/api_async.py
@@ -399,6 +399,9 @@ class AsyncStrictIota:
                 transactions=transactions,
         )
 
+    # Add an alias, more descriptive
+    is_confirmed = get_inclusion_states
+
     async def get_missing_transactions(self) -> dict:
         """
         Returns all transaction hashes that a node is currently requesting


### PR DESCRIPTION
# Description of change

Fixes #320 

Add a new extended api call `is_confirmed` to determine if a set of transactions have been confirmed by the network. It is an alias for `get_inclusion_states`.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Just an alias, tests remain the same.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/` directory and/or `docstring`s in source code)
- [x] I have followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) Style Guide in my code.
- [x] New and existing unit tests pass locally with my changes
