### PR TITLE
Fixes #315 Remove `threshold` param from `get_balances` api call

### DIFF
--- a/iota/api.py
+++ b/iota/api.py
@@ -314,13 +314,11 @@ class StrictIota(AsyncStrictIota):
     def get_balances(
             self,
             addresses: Iterable[Address],
-            threshold: int = 100,
             tips: Optional[Iterable[TransactionHash]] = None,
     ) -> dict:
         """
-        Similar to :py:meth:`get_inclusion_states`. Returns the
-        confirmed balance which a list of addresses have at the latest
-        confirmed milestone.
+        Returns the confirmed balance which a list of addresses have at the
+        latest confirmed milestone.
 
         In addition to the balances, it also returns the milestone as
         well as the index with which the confirmed balance was
@@ -329,9 +327,6 @@ class StrictIota(AsyncStrictIota):
 
         :param Iterable[Address] addresses:
             List of addresses to get the confirmed balance for.
-
-        :param int threshold:
-            Confirmation threshold between 0 and 100.
 
         :param Optional[Iterable[TransactionHash]] tips:
             Tips whose history of transactions to traverse to find the balance.
@@ -364,7 +359,6 @@ class StrictIota(AsyncStrictIota):
         return asyncio.get_event_loop().run_until_complete(
                 super().get_balances(
                         addresses,
-                        threshold,
                         tips,
                 )
         )

--- a/iota/api_async.py
+++ b/iota/api_async.py
@@ -316,13 +316,11 @@ class AsyncStrictIota:
     async def get_balances(
             self,
             addresses: Iterable[Address],
-            threshold: int = 100,
             tips: Optional[Iterable[TransactionHash]] = None,
     ) -> dict:
         """
-        Similar to :py:meth:`get_inclusion_states`. Returns the
-        confirmed balance which a list of addresses have at the latest
-        confirmed milestone.
+        Returns the confirmed balance which a list of addresses have at the
+        latest confirmed milestone.
 
         In addition to the balances, it also returns the milestone as
         well as the index with which the confirmed balance was
@@ -362,7 +360,6 @@ class AsyncStrictIota:
         """
         return await core.GetBalancesCommand(self.adapter)(
                 addresses=addresses,
-                threshold=threshold,
                 tips=tips,
         )
 

--- a/iota/api_async.py
+++ b/iota/api_async.py
@@ -330,9 +330,6 @@ class AsyncStrictIota:
         :param Iterable[Address] addresses:
             List of addresses to get the confirmed balance for.
 
-        :param int threshold:
-            Confirmation threshold between 0 and 100.
-
         :param Optional[Iterable[TransactionHash]] tips:
             Tips whose history of transactions to traverse to find the balance.
 

--- a/iota/commands/core/get_balances.py
+++ b/iota/commands/core/get_balances.py
@@ -35,17 +35,11 @@ class GetBalancesRequestFilter(RequestFilter):
                         f.Unicode(encoding='ascii', normalize=False),
                     ),
 
-                'threshold':
-                    f.Type(int) |
-                    f.Min(0) |
-                    f.Max(100) |
-                    f.Optional(default=100),
-
                 'tips': StringifiedTrytesArray(TransactionHash),
             },
 
             allow_missing_keys={
-                'threshold', 'tips',
+                'tips',
             },
         )
 

--- a/test/commands/core/get_balances_test.py
+++ b/test/commands/core/get_balances_test.py
@@ -40,8 +40,6 @@ class GetBalancesRequestFilterTestCase(BaseFilterTestCase):
         request = {
             # Raw trytes are extracted to match the IRI's JSON protocol.
             'addresses': [self.trytes1, self.trytes2],
-
-            'threshold': 80,
         }
 
         filter_ = self._filter(request)
@@ -55,8 +53,6 @@ class GetBalancesRequestFilterTestCase(BaseFilterTestCase):
         """
         request = {
             'addresses': [self.trytes1, self.trytes2],
-
-            'threshold': 80,
 
             'tips': [self.trytes3],
         }
@@ -76,8 +72,6 @@ class GetBalancesRequestFilterTestCase(BaseFilterTestCase):
                 Address(self.trytes1),
                 bytearray(self.trytes2.encode('ascii')),
             ],
-
-            'threshold': 80,
         }
 
         filter_ = self._filter(request)
@@ -88,28 +82,6 @@ class GetBalancesRequestFilterTestCase(BaseFilterTestCase):
 
             {
                 'addresses': [self.trytes1, self.trytes2],
-                'threshold': 80,
-            },
-        )
-
-    def test_pass_threshold_optional(self):
-        """
-        The incoming request does not contain a ``threshold`` value, so the
-        default value is assumed.
-        """
-        request = {
-            'addresses': [Address(self.trytes1)],
-        }
-
-        filter_ = self._filter(request)
-
-        self.assertFilterPasses(filter_)
-        self.assertDictEqual(
-            filter_.cleaned_data,
-
-            {
-                'addresses': [Address(self.trytes1)],
-                'threshold': 100,
             },
         )
 
@@ -133,13 +105,12 @@ class GetBalancesRequestFilterTestCase(BaseFilterTestCase):
             {
                 'addresses': [Address(self.trytes1)],
 
-                # I've had a perfectly wonderful evening.
-                # But this wasn't it.
-                'foo': 'bar',
+                # `threshold` parameter deprecated in IRI 1.8.6
+                'threshold': 100,
             },
 
             {
-                'foo': [f.FilterMapper.CODE_EXTRA_KEY],
+                'threshold': [f.FilterMapper.CODE_EXTRA_KEY],
             },
         )
 
@@ -199,71 +170,6 @@ class GetBalancesRequestFilterTestCase(BaseFilterTestCase):
                 'addresses.3':  [Trytes.CODE_NOT_TRYTES],
                 'addresses.5':  [f.Type.CODE_WRONG_TYPE],
                 'addresses.6':  [Trytes.CODE_WRONG_FORMAT],
-            },
-        )
-
-    def test_fail_threshold_float(self):
-        """
-        `threshold` is a float.
-        """
-        self.assertFilterErrors(
-            {
-                # Even with an empty fpart, floats are not accepted.
-                'threshold': 86.0,
-
-                'addresses': [Address(self.trytes1)],
-            },
-
-            {
-                'threshold': [f.Type.CODE_WRONG_TYPE],
-            },
-        )
-
-    def test_fail_threshold_string(self):
-        """
-        ``threshold`` is a string.
-        """
-        self.assertFilterErrors(
-            {
-                'threshold': '86',
-
-                'addresses': [Address(self.trytes1)],
-            },
-
-            {
-                'threshold': [f.Type.CODE_WRONG_TYPE],
-            },
-        )
-
-    def test_fail_threshold_too_small(self):
-        """
-        ``threshold`` is less than 0.
-        """
-        self.assertFilterErrors(
-            {
-                'threshold': -1,
-
-                'addresses': [Address(self.trytes1)],
-            },
-
-            {
-                'threshold': [f.Min.CODE_TOO_SMALL],
-            },
-        )
-
-    def test_fail_threshold_too_big(self):
-        """
-        ``threshold`` is greater than 100.
-        """
-        self.assertFilterErrors(
-            {
-                'threshold': 101,
-
-                'addresses': [Address(self.trytes1)],
-            },
-
-            {
-                'threshold': [f.Max.CODE_TOO_BIG],
             },
         )
 


### PR DESCRIPTION
# Description of change

fixes #315 

Remove unused `threshold` parameter from `get_balances` api call.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Modified test case pass.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/` directory and/or `docstring`s in source code)
- [x] I have followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) Style Guide in my code.
- [x] New and existing unit tests pass locally with my changes
