### PR TITLE
Update response filter of `get_node_info`

### DIFF
--- a/iota/commands/core/get_node_info.py
+++ b/iota/commands/core/get_node_info.py
@@ -1,6 +1,6 @@
 import filters as f
 
-from iota import TransactionHash
+from iota import TransactionHash, Address
 from iota.commands import FilterCommand, RequestFilter, ResponseFilter
 from iota.filters import Trytes
 
@@ -34,6 +34,8 @@ class GetNodeInfoRequestFilter(RequestFilter):
 class GetNodeInfoResponseFilter(ResponseFilter):
     def __init__(self) -> None:
         super(GetNodeInfoResponseFilter, self).__init__({
+            'coordinatorAddress':
+                f.ByteString(encoding='ascii') | Trytes(Address),
             'latestMilestone':
                 f.ByteString(encoding='ascii') | Trytes(TransactionHash),
 

--- a/test/commands/core/get_node_info_test.py
+++ b/test/commands/core/get_node_info_test.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 import filters as f
 from filters.test import BaseFilterTestCase
-from iota import Iota, TransactionHash, AsyncIota
+from iota import Iota, TransactionHash, AsyncIota, Address
 from iota.adapter import MockAdapter, async_return
 from iota.commands.core.get_node_info import GetNodeInfoCommand
 from test import patch, MagicMock, async_test
@@ -50,6 +50,9 @@ class GetNodeInfoResponseFilterTestCase(BaseFilterTestCase):
     response = {
       'appName': 'IRI',
       'appVersion': '1.0.8.nu',
+      'coordinatorAddress':
+          'BUPQSYFUFMUOJVGVFKPCOULCQNTJPYJOTATSILTN'
+          'ZKOPQWHENIDIH9HJEUOTNV9LNGHCTHMHWOPLZOJCJ',
       'duration': 1,
       'jreAvailableProcessors': 4,
       'jreFreeMemory': 91707424,
@@ -81,6 +84,11 @@ class GetNodeInfoResponseFilterTestCase(BaseFilterTestCase):
       {
         'appName': 'IRI',
         'appVersion': '1.0.8.nu',
+        'coordinatorAddress':
+          Address(
+            b'BUPQSYFUFMUOJVGVFKPCOULCQNTJPYJOTATSILTN'
+            b'ZKOPQWHENIDIH9HJEUOTNV9LNGHCTHMHWOPLZOJCJ'
+          ),
         'duration': 1,
         'jreAvailableProcessors': 4,
         'jreFreeMemory': 91707424,


### PR DESCRIPTION
# Description of change

`coordinatorAddress` in response of `get_node_info` is returned as an `Address` object instead of plain text.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Test case modified and passes.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`docs/` directory and/or `docstring`s in source code)
- [x] New and existing unit tests pass locally with my changes
